### PR TITLE
test(audit-marten): close UNIT and GUARD coverage gaps

### DIFF
--- a/tests/Encina.GuardTests/AuditMarten/AuditEntryModelsGuardTests.cs
+++ b/tests/Encina.GuardTests/AuditMarten/AuditEntryModelsGuardTests.cs
@@ -1,0 +1,138 @@
+using Encina.Audit.Marten.Events;
+using Encina.Audit.Marten.Projections;
+using Encina.Security.Audit;
+
+namespace Encina.GuardTests.AuditMarten;
+
+/// <summary>
+/// Guard tests exercising the audit Marten event records and read models (POCO validation).
+/// These cover property assignment paths on the public event and read model types.
+/// </summary>
+public class AuditEntryModelsGuardTests
+{
+    [Fact]
+    public void AuditEntryRecordedEvent_RequiredProperties_AreAssignable()
+    {
+        var evt = new AuditEntryRecordedEvent
+        {
+            Id = Guid.NewGuid(),
+            CorrelationId = "c",
+            Action = "A",
+            EntityType = "E",
+            Outcome = 0,
+            TimestampUtc = DateTime.UtcNow,
+            StartedAtUtc = DateTimeOffset.UtcNow,
+            CompletedAtUtc = DateTimeOffset.UtcNow,
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        evt.ShouldNotBeNull();
+        evt.CorrelationId.ShouldBe("c");
+        evt.Action.ShouldBe("A");
+        evt.EntityType.ShouldBe("E");
+        evt.TemporalKeyPeriod.ShouldBe("2026-03");
+    }
+
+    [Fact]
+    public void ReadAuditEntryRecordedEvent_RequiredProperties_AreAssignable()
+    {
+        var evt = new ReadAuditEntryRecordedEvent
+        {
+            Id = Guid.NewGuid(),
+            EntityType = "E",
+            EntityId = null,
+            AccessedAtUtc = DateTimeOffset.UtcNow,
+            AccessMethod = 0,
+            EntityCount = 0,
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        evt.ShouldNotBeNull();
+        evt.EntityType.ShouldBe("E");
+        evt.TemporalKeyPeriod.ShouldBe("2026-03");
+    }
+
+    [Fact]
+    public void AuditEntryReadModel_Defaults_AreInitialized()
+    {
+        var model = new AuditEntryReadModel();
+        model.CorrelationId.ShouldBe(string.Empty);
+        model.Action.ShouldBe(string.Empty);
+        model.EntityType.ShouldBe(string.Empty);
+        model.TemporalKeyPeriod.ShouldBe(string.Empty);
+        model.IsShredded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AuditEntryReadModel_AllProperties_AreSettable()
+    {
+        var id = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var offset = DateTimeOffset.UtcNow;
+
+        var model = new AuditEntryReadModel
+        {
+            Id = id,
+            CorrelationId = "c",
+            Action = "A",
+            EntityType = "E",
+            EntityId = "1",
+            Outcome = AuditOutcome.Success,
+            ErrorMessage = "err",
+            TimestampUtc = now,
+            StartedAtUtc = offset,
+            CompletedAtUtc = offset.AddSeconds(1),
+            RequestPayloadHash = "h",
+            TenantId = "t",
+            UserId = "u",
+            IpAddress = "ip",
+            UserAgent = "ua",
+            RequestPayload = "req",
+            ResponsePayload = "resp",
+            MetadataJson = "{}",
+            IsShredded = true,
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        model.Id.ShouldBe(id);
+        model.IsShredded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ReadAuditEntryReadModel_Defaults_AreInitialized()
+    {
+        var model = new ReadAuditEntryReadModel();
+        model.EntityType.ShouldBe(string.Empty);
+        model.TemporalKeyPeriod.ShouldBe(string.Empty);
+        model.EntityCount.ShouldBe(0);
+        model.IsShredded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ReadAuditEntryReadModel_AllProperties_AreSettable()
+    {
+        var id = Guid.NewGuid();
+        var accessed = DateTimeOffset.UtcNow;
+
+        var model = new ReadAuditEntryReadModel
+        {
+            Id = id,
+            EntityType = "E",
+            EntityId = "1",
+            AccessedAtUtc = accessed,
+            AccessMethod = ReadAccessMethod.Repository,
+            EntityCount = 2,
+            CorrelationId = "c",
+            TenantId = "t",
+            UserId = "u",
+            Purpose = "p",
+            MetadataJson = "{}",
+            IsShredded = false,
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        model.Id.ShouldBe(id);
+        model.AccessMethod.ShouldBe(ReadAccessMethod.Repository);
+        model.EntityCount.ShouldBe(2);
+    }
+}

--- a/tests/Encina.GuardTests/AuditMarten/AuditEntryProjectionGuardTests.cs
+++ b/tests/Encina.GuardTests/AuditMarten/AuditEntryProjectionGuardTests.cs
@@ -1,0 +1,103 @@
+using Encina.Audit.Marten;
+using Encina.Audit.Marten.Crypto;
+using Encina.Audit.Marten.Events;
+using Encina.Audit.Marten.Projections;
+using Encina.Security.Audit;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Encina.GuardTests.AuditMarten;
+
+/// <summary>
+/// Guard tests for <see cref="AuditEntryProjection"/> and <see cref="ReadAuditEntryProjection"/>.
+/// Ensures the projection types can be constructed and invoked with a real service provider.
+/// </summary>
+public class AuditEntryProjectionGuardTests
+{
+    private static ServiceProvider BuildServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ITemporalKeyProvider>(new InMemoryTemporalKeyProvider(
+            new FakeTimeProvider(new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero)),
+            NullLogger<InMemoryTemporalKeyProvider>.Instance));
+        services.Configure<MartenAuditOptions>(_ => { });
+        services.AddLogging();
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void AuditEntryProjection_Constructor_DoesNotThrow()
+    {
+        var projection = new AuditEntryProjection();
+        projection.ShouldNotBeNull();
+        projection.Name.ShouldBe("AuditEntryProjection");
+    }
+
+    [Fact]
+    public void ReadAuditEntryProjection_Constructor_DoesNotThrow()
+    {
+        var projection = new ReadAuditEntryProjection();
+        projection.ShouldNotBeNull();
+        projection.Name.ShouldBe("ReadAuditEntryProjection");
+    }
+
+    [Fact]
+    public async Task AuditEntryProjection_Create_MissingKey_ReturnsShredded()
+    {
+        var projection = new AuditEntryProjection();
+        var services = BuildServiceProvider();
+
+        var dummyKey = new byte[32];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(dummyKey);
+        var encrypted = EncryptedField.Encrypt("data", dummyKey, "temporal:9999-12:v1");
+
+        var evt = new AuditEntryRecordedEvent
+        {
+            Id = Guid.NewGuid(),
+            CorrelationId = "c",
+            Action = "A",
+            EntityType = "E",
+            Outcome = 0,
+            TimestampUtc = DateTime.UtcNow,
+            StartedAtUtc = DateTimeOffset.UtcNow,
+            CompletedAtUtc = DateTimeOffset.UtcNow,
+            EncryptedUserId = encrypted,
+            TemporalKeyPeriod = "9999-12"
+        };
+
+        var result = await projection.Create(evt, services);
+
+        result.IsShredded.ShouldBeTrue();
+        result.UserId.ShouldBe("[SHREDDED]");
+    }
+
+    [Fact]
+    public async Task ReadAuditEntryProjection_Create_MissingKey_ReturnsShredded()
+    {
+        var projection = new ReadAuditEntryProjection();
+        var services = BuildServiceProvider();
+
+        var dummyKey = new byte[32];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(dummyKey);
+        var encrypted = EncryptedField.Encrypt("data", dummyKey, "temporal:9999-12:v1");
+
+        var evt = new ReadAuditEntryRecordedEvent
+        {
+            Id = Guid.NewGuid(),
+            EntityType = "E",
+            EntityId = null,
+            AccessedAtUtc = DateTimeOffset.UtcNow,
+            AccessMethod = (int)ReadAccessMethod.Repository,
+            EntityCount = 0,
+            EncryptedUserId = encrypted,
+            TemporalKeyPeriod = "9999-12"
+        };
+
+        var result = await projection.Create(evt, services);
+
+        result.IsShredded.ShouldBeTrue();
+        result.UserId.ShouldBe("[SHREDDED]");
+    }
+}

--- a/tests/Encina.GuardTests/AuditMarten/MartenAuditErrorsGuardTests.cs
+++ b/tests/Encina.GuardTests/AuditMarten/MartenAuditErrorsGuardTests.cs
@@ -1,0 +1,142 @@
+using Encina.Audit.Marten;
+
+namespace Encina.GuardTests.AuditMarten;
+
+/// <summary>
+/// Guard tests covering <see cref="MartenAuditErrors"/> factory methods, exercising every
+/// public factory method with and without exception arguments.
+/// </summary>
+public class MartenAuditErrorsGuardTests
+{
+    [Fact]
+    public void EncryptionFailed_WithoutException_ReturnsError()
+    {
+        var error = MartenAuditErrors.EncryptionFailed(Guid.NewGuid(), "2026-03");
+        error.Message.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void EncryptionFailed_WithException_AttachesException()
+    {
+        var ex = new InvalidOperationException("fail");
+        var error = MartenAuditErrors.EncryptionFailed(Guid.NewGuid(), "2026-03", ex);
+        error.Exception.IsSome.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DecryptionFailed_WithoutException_ReturnsError()
+    {
+        var error = MartenAuditErrors.DecryptionFailed(Guid.NewGuid(), "2026-03");
+        error.Message.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void DecryptionFailed_WithException_AttachesException()
+    {
+        var ex = new InvalidOperationException("dec");
+        var error = MartenAuditErrors.DecryptionFailed(Guid.NewGuid(), "2026-03", ex);
+        error.Exception.IsSome.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void KeyNotFound_ReturnsError()
+    {
+        var error = MartenAuditErrors.KeyNotFound("2026-03");
+        error.Message.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void KeyDestructionFailed_WithoutException_ReturnsError()
+    {
+        var error = MartenAuditErrors.KeyDestructionFailed(DateTime.UtcNow);
+        error.Message.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void KeyDestructionFailed_WithException_AttachesException()
+    {
+        var ex = new TimeoutException("timeout");
+        var error = MartenAuditErrors.KeyDestructionFailed(DateTime.UtcNow, ex);
+        error.Exception.IsSome.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ProjectionFailed_WithoutException_ReturnsError()
+    {
+        var error = MartenAuditErrors.ProjectionFailed("AuditEntryProjection");
+        error.Message.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void ProjectionFailed_WithException_AttachesException()
+    {
+        var ex = new InvalidOperationException("proj");
+        var error = MartenAuditErrors.ProjectionFailed("P", ex);
+        error.Exception.IsSome.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void QueryFailed_WithoutException_ReturnsError()
+    {
+        var error = MartenAuditErrors.QueryFailed("ByEntity");
+        error.Message.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void QueryFailed_WithException_AttachesException()
+    {
+        var ex = new InvalidOperationException("q");
+        var error = MartenAuditErrors.QueryFailed("ByEntity", ex);
+        error.Exception.IsSome.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void StoreUnavailable_WithoutException_ReturnsError()
+    {
+        var error = MartenAuditErrors.StoreUnavailable("RecordAsync");
+        error.Message.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void StoreUnavailable_WithException_AttachesException()
+    {
+        var ex = new InvalidOperationException("store");
+        var error = MartenAuditErrors.StoreUnavailable("op", ex);
+        error.Exception.IsSome.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void InvalidPeriod_WithValidString_ReturnsError()
+    {
+        var error = MartenAuditErrors.InvalidPeriod("bad");
+        error.Message.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void InvalidPeriod_WithNull_ReturnsError()
+    {
+        var error = MartenAuditErrors.InvalidPeriod(null);
+        error.Message.ShouldContain("(null)");
+    }
+
+    [Fact]
+    public void ShreddedEntry_ReturnsError()
+    {
+        var error = MartenAuditErrors.ShreddedEntry(Guid.NewGuid(), "2020-01");
+        error.Message.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void AllErrorCodes_StartWithAuditMarten()
+    {
+        MartenAuditErrors.EncryptionFailedCode.ShouldStartWith("audit.marten.");
+        MartenAuditErrors.DecryptionFailedCode.ShouldStartWith("audit.marten.");
+        MartenAuditErrors.KeyNotFoundCode.ShouldStartWith("audit.marten.");
+        MartenAuditErrors.KeyDestructionFailedCode.ShouldStartWith("audit.marten.");
+        MartenAuditErrors.ProjectionFailedCode.ShouldStartWith("audit.marten.");
+        MartenAuditErrors.QueryFailedCode.ShouldStartWith("audit.marten.");
+        MartenAuditErrors.StoreUnavailableCode.ShouldStartWith("audit.marten.");
+        MartenAuditErrors.InvalidPeriodCode.ShouldStartWith("audit.marten.");
+        MartenAuditErrors.ShreddedEntryCode.ShouldStartWith("audit.marten.");
+    }
+}

--- a/tests/Encina.GuardTests/AuditMarten/MartenAuditOptionsGuardTests.cs
+++ b/tests/Encina.GuardTests/AuditMarten/MartenAuditOptionsGuardTests.cs
@@ -1,0 +1,55 @@
+using Encina.Audit.Marten;
+using Encina.Audit.Marten.Crypto;
+
+namespace Encina.GuardTests.AuditMarten;
+
+/// <summary>
+/// Guard tests exercising <see cref="MartenAuditOptions"/> property assignments and defaults.
+/// </summary>
+public class MartenAuditOptionsGuardTests
+{
+    [Fact]
+    public void Defaults_AreSet()
+    {
+        var options = new MartenAuditOptions();
+
+        options.TemporalGranularity.ShouldBe(TemporalKeyGranularity.Monthly);
+        options.EncryptionScope.ShouldBe(AuditEncryptionScope.PiiFieldsOnly);
+        options.RetentionPeriod.ShouldBe(TimeSpan.FromDays(2555));
+        options.EnableAutoPurge.ShouldBeFalse();
+        options.PurgeIntervalHours.ShouldBe(24);
+        options.ShreddedPlaceholder.ShouldBe("[SHREDDED]");
+        options.AddHealthCheck.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Constants_AreExposed()
+    {
+        MartenAuditOptions.DefaultShreddedPlaceholder.ShouldBe("[SHREDDED]");
+        MartenAuditOptions.DefaultRetentionDays.ShouldBe(2555);
+        MartenAuditOptions.DefaultPurgeIntervalHours.ShouldBe(24);
+    }
+
+    [Fact]
+    public void AllProperties_CanBeAssigned()
+    {
+        var options = new MartenAuditOptions
+        {
+            TemporalGranularity = TemporalKeyGranularity.Yearly,
+            EncryptionScope = AuditEncryptionScope.AllFields,
+            RetentionPeriod = TimeSpan.FromDays(365),
+            EnableAutoPurge = true,
+            PurgeIntervalHours = 12,
+            ShreddedPlaceholder = "<REDACTED>",
+            AddHealthCheck = true
+        };
+
+        options.TemporalGranularity.ShouldBe(TemporalKeyGranularity.Yearly);
+        options.EncryptionScope.ShouldBe(AuditEncryptionScope.AllFields);
+        options.RetentionPeriod.ShouldBe(TimeSpan.FromDays(365));
+        options.EnableAutoPurge.ShouldBeTrue();
+        options.PurgeIntervalHours.ShouldBe(12);
+        options.ShreddedPlaceholder.ShouldBe("<REDACTED>");
+        options.AddHealthCheck.ShouldBeTrue();
+    }
+}

--- a/tests/Encina.GuardTests/AuditMarten/TemporalPeriodHelperGuardTests.cs
+++ b/tests/Encina.GuardTests/AuditMarten/TemporalPeriodHelperGuardTests.cs
@@ -1,0 +1,165 @@
+using Encina.Audit.Marten;
+using Encina.Audit.Marten.Crypto;
+
+namespace Encina.GuardTests.AuditMarten;
+
+/// <summary>
+/// Guard tests exercising <see cref="TemporalPeriodHelper"/> utility methods and branches.
+/// </summary>
+public class TemporalPeriodHelperGuardTests
+{
+    [Fact]
+    public void GetPeriod_Monthly_ReturnsExpected()
+    {
+        var ts = new DateTimeOffset(2026, 3, 15, 0, 0, 0, TimeSpan.Zero);
+        TemporalPeriodHelper.GetPeriod(ts, TemporalKeyGranularity.Monthly).ShouldBe("2026-03");
+    }
+
+    [Fact]
+    public void GetPeriod_Quarterly_ReturnsExpected()
+    {
+        var ts = new DateTimeOffset(2026, 5, 15, 0, 0, 0, TimeSpan.Zero);
+        TemporalPeriodHelper.GetPeriod(ts, TemporalKeyGranularity.Quarterly).ShouldBe("2026-Q2");
+    }
+
+    [Fact]
+    public void GetPeriod_Yearly_ReturnsExpected()
+    {
+        var ts = new DateTimeOffset(2026, 3, 15, 0, 0, 0, TimeSpan.Zero);
+        TemporalPeriodHelper.GetPeriod(ts, TemporalKeyGranularity.Yearly).ShouldBe("2026");
+    }
+
+    [Fact]
+    public void GetPeriod_InvalidGranularity_Throws()
+    {
+        var ts = new DateTimeOffset(2026, 3, 15, 0, 0, 0, TimeSpan.Zero);
+        Should.Throw<ArgumentOutOfRangeException>(() =>
+            TemporalPeriodHelper.GetPeriod(ts, (TemporalKeyGranularity)999));
+    }
+
+    [Fact]
+    public void GetPeriod_DateTimeOverload_Works()
+    {
+        var ts = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+        TemporalPeriodHelper.GetPeriod(ts, TemporalKeyGranularity.Monthly).ShouldBe("2026-03");
+    }
+
+    [Fact]
+    public void FormatKeyId_ReturnsExpectedFormat()
+    {
+        TemporalPeriodHelper.FormatKeyId("2026-03", 2).ShouldBe("temporal:2026-03:v2");
+    }
+
+    [Fact]
+    public void FormatDestroyedMarkerId_ReturnsExpectedFormat()
+    {
+        TemporalPeriodHelper.FormatDestroyedMarkerId("2026-03").ShouldBe("temporal-destroyed:2026-03");
+    }
+
+    [Fact]
+    public void EnumeratePeriods_Monthly_ReturnsAllMonthsInRange()
+    {
+        var from = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var to = new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var periods = TemporalPeriodHelper.EnumeratePeriods(from, to, TemporalKeyGranularity.Monthly).ToList();
+
+        periods.ShouldContain("2026-01");
+        periods.ShouldContain("2026-02");
+        periods.ShouldContain("2026-03");
+    }
+
+    [Fact]
+    public void EnumeratePeriods_Yearly_ReturnsYears()
+    {
+        var from = new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var to = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+
+        var periods = TemporalPeriodHelper.EnumeratePeriods(from, to, TemporalKeyGranularity.Yearly).ToList();
+
+        periods.ShouldContain("2024");
+        periods.ShouldContain("2025");
+        periods.ShouldContain("2026");
+    }
+
+    [Fact]
+    public void EnumeratePeriods_Quarterly_ReturnsQuarters()
+    {
+        var from = new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero);
+        var to = new DateTimeOffset(2026, 8, 15, 0, 0, 0, TimeSpan.Zero);
+
+        var periods = TemporalPeriodHelper.EnumeratePeriods(from, to, TemporalKeyGranularity.Quarterly).ToList();
+
+        periods.ShouldContain("2026-Q1");
+        periods.ShouldContain("2026-Q2");
+        periods.ShouldContain("2026-Q3");
+    }
+
+    [Fact]
+    public void TryParsePeriodToDate_MonthlyValid_ReturnsTrue()
+    {
+        var ok = TemporalPeriodHelper.TryParsePeriodToDate("2026-03", TemporalKeyGranularity.Monthly, out var date);
+        ok.ShouldBeTrue();
+        date.Year.ShouldBe(2026);
+        date.Month.ShouldBe(3);
+    }
+
+    [Fact]
+    public void TryParsePeriodToDate_MonthlyInvalid_ReturnsFalse()
+    {
+        var ok = TemporalPeriodHelper.TryParsePeriodToDate("not-a-date", TemporalKeyGranularity.Monthly, out _);
+        ok.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParsePeriodToDate_QuarterlyValid_ReturnsTrue()
+    {
+        var ok = TemporalPeriodHelper.TryParsePeriodToDate("2026-Q2", TemporalKeyGranularity.Quarterly, out var date);
+        ok.ShouldBeTrue();
+        date.Year.ShouldBe(2026);
+        date.Month.ShouldBe(4);
+    }
+
+    [Fact]
+    public void TryParsePeriodToDate_QuarterlyInvalidQuarter_ReturnsFalse()
+    {
+        var ok = TemporalPeriodHelper.TryParsePeriodToDate("2026-Q9", TemporalKeyGranularity.Quarterly, out _);
+        ok.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParsePeriodToDate_YearlyValid_ReturnsTrue()
+    {
+        var ok = TemporalPeriodHelper.TryParsePeriodToDate("2026", TemporalKeyGranularity.Yearly, out var date);
+        ok.ShouldBeTrue();
+        date.Year.ShouldBe(2026);
+    }
+
+    [Fact]
+    public void TryParsePeriodToDate_YearlyInvalid_ReturnsFalse()
+    {
+        var ok = TemporalPeriodHelper.TryParsePeriodToDate("notyear", TemporalKeyGranularity.Yearly, out _);
+        ok.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParsePeriodToDate_Null_ReturnsFalse()
+    {
+        var ok = TemporalPeriodHelper.TryParsePeriodToDate(null!, TemporalKeyGranularity.Monthly, out _);
+        ok.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParsePeriodToDate_Empty_ReturnsFalse()
+    {
+        var ok = TemporalPeriodHelper.TryParsePeriodToDate("", TemporalKeyGranularity.Monthly, out _);
+        ok.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryParsePeriodToDate_InvalidGranularity_ReturnsFalse()
+    {
+        var ok = TemporalPeriodHelper.TryParsePeriodToDate("2026", (TemporalKeyGranularity)999, out _);
+        ok.ShouldBeFalse();
+    }
+}

--- a/tests/Encina.UnitTests/AuditMarten/AuditEntryModelsTests.cs
+++ b/tests/Encina.UnitTests/AuditMarten/AuditEntryModelsTests.cs
@@ -1,0 +1,275 @@
+using Encina.Audit.Marten.Events;
+using Encina.Audit.Marten.Projections;
+using Encina.Security.Audit;
+
+namespace Encina.UnitTests.AuditMarten;
+
+/// <summary>
+/// Unit tests exercising audit Marten POCO records and read models (events + projected models).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Provider", "Marten")]
+public sealed class AuditEntryModelsTests
+{
+    #region AuditEntryRecordedEvent
+
+    [Fact]
+    public void AuditEntryRecordedEvent_PreservesAllProperties()
+    {
+        var id = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        var nowOffset = DateTimeOffset.UtcNow;
+
+        var evt = new AuditEntryRecordedEvent
+        {
+            Id = id,
+            CorrelationId = "corr-1",
+            Action = "Create",
+            EntityType = "Order",
+            EntityId = "order-42",
+            Outcome = (int)AuditOutcome.Success,
+            ErrorMessage = null,
+            TimestampUtc = now,
+            StartedAtUtc = nowOffset,
+            CompletedAtUtc = nowOffset.AddSeconds(1),
+            RequestPayloadHash = "hash123",
+            TenantId = "tenant-1",
+            TemporalKeyPeriod = "2026-03",
+            EncryptedUserId = null,
+            EncryptedIpAddress = null,
+            EncryptedUserAgent = null,
+            EncryptedRequestPayload = null,
+            EncryptedResponsePayload = null,
+            EncryptedMetadata = null
+        };
+
+        evt.Id.ShouldBe(id);
+        evt.CorrelationId.ShouldBe("corr-1");
+        evt.Action.ShouldBe("Create");
+        evt.EntityType.ShouldBe("Order");
+        evt.EntityId.ShouldBe("order-42");
+        evt.Outcome.ShouldBe((int)AuditOutcome.Success);
+        evt.ErrorMessage.ShouldBeNull();
+        evt.TimestampUtc.ShouldBe(now);
+        evt.StartedAtUtc.ShouldBe(nowOffset);
+        evt.RequestPayloadHash.ShouldBe("hash123");
+        evt.TenantId.ShouldBe("tenant-1");
+        evt.TemporalKeyPeriod.ShouldBe("2026-03");
+    }
+
+    [Fact]
+    public void AuditEntryRecordedEvent_RecordEquality_WorksByValue()
+    {
+        var fixedTime = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+        var fixedOffset = new DateTimeOffset(fixedTime, TimeSpan.Zero);
+        var id = Guid.NewGuid();
+
+        var a = new AuditEntryRecordedEvent
+        {
+            Id = id,
+            CorrelationId = "c",
+            Action = "A",
+            EntityType = "E",
+            Outcome = 0,
+            TimestampUtc = fixedTime,
+            StartedAtUtc = fixedOffset,
+            CompletedAtUtc = fixedOffset,
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        var b = new AuditEntryRecordedEvent
+        {
+            Id = id,
+            CorrelationId = "c",
+            Action = "A",
+            EntityType = "E",
+            Outcome = 0,
+            TimestampUtc = fixedTime,
+            StartedAtUtc = fixedOffset,
+            CompletedAtUtc = fixedOffset,
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        a.ShouldBe(b);
+        a.GetHashCode().ShouldBe(b.GetHashCode());
+    }
+
+    #endregion
+
+    #region ReadAuditEntryRecordedEvent
+
+    [Fact]
+    public void ReadAuditEntryRecordedEvent_PreservesAllProperties()
+    {
+        var id = Guid.NewGuid();
+        var accessed = DateTimeOffset.UtcNow;
+
+        var evt = new ReadAuditEntryRecordedEvent
+        {
+            Id = id,
+            EntityType = "Patient",
+            EntityId = "p-1",
+            AccessedAtUtc = accessed,
+            AccessMethod = (int)ReadAccessMethod.Repository,
+            EntityCount = 3,
+            CorrelationId = "cr",
+            TenantId = "t",
+            TemporalKeyPeriod = "2026-03",
+            EncryptedUserId = null,
+            EncryptedPurpose = null,
+            EncryptedMetadata = null
+        };
+
+        evt.Id.ShouldBe(id);
+        evt.EntityType.ShouldBe("Patient");
+        evt.EntityId.ShouldBe("p-1");
+        evt.AccessedAtUtc.ShouldBe(accessed);
+        evt.AccessMethod.ShouldBe((int)ReadAccessMethod.Repository);
+        evt.EntityCount.ShouldBe(3);
+        evt.CorrelationId.ShouldBe("cr");
+        evt.TenantId.ShouldBe("t");
+        evt.TemporalKeyPeriod.ShouldBe("2026-03");
+    }
+
+    #endregion
+
+    #region AuditEntryReadModel
+
+    [Fact]
+    public void AuditEntryReadModel_DefaultValues_AreSensible()
+    {
+        var model = new AuditEntryReadModel();
+
+        model.Id.ShouldBe(Guid.Empty);
+        model.CorrelationId.ShouldBe(string.Empty);
+        model.Action.ShouldBe(string.Empty);
+        model.EntityType.ShouldBe(string.Empty);
+        model.EntityId.ShouldBeNull();
+        model.ErrorMessage.ShouldBeNull();
+        model.RequestPayloadHash.ShouldBeNull();
+        model.TenantId.ShouldBeNull();
+        model.UserId.ShouldBeNull();
+        model.IpAddress.ShouldBeNull();
+        model.UserAgent.ShouldBeNull();
+        model.RequestPayload.ShouldBeNull();
+        model.ResponsePayload.ShouldBeNull();
+        model.MetadataJson.ShouldBeNull();
+        model.IsShredded.ShouldBeFalse();
+        model.TemporalKeyPeriod.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void AuditEntryReadModel_CanSetAllProperties()
+    {
+        var id = Guid.NewGuid();
+        var ts = DateTime.UtcNow;
+        var startedAt = DateTimeOffset.UtcNow;
+        var completedAt = startedAt.AddMilliseconds(50);
+
+        var model = new AuditEntryReadModel
+        {
+            Id = id,
+            CorrelationId = "c",
+            Action = "Update",
+            EntityType = "Customer",
+            EntityId = "cust-1",
+            Outcome = AuditOutcome.Success,
+            ErrorMessage = null,
+            TimestampUtc = ts,
+            StartedAtUtc = startedAt,
+            CompletedAtUtc = completedAt,
+            RequestPayloadHash = "h",
+            TenantId = "t",
+            UserId = "u",
+            IpAddress = "ip",
+            UserAgent = "ua",
+            RequestPayload = "req",
+            ResponsePayload = "resp",
+            MetadataJson = "{}",
+            IsShredded = false,
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        model.Id.ShouldBe(id);
+        model.CorrelationId.ShouldBe("c");
+        model.Action.ShouldBe("Update");
+        model.EntityType.ShouldBe("Customer");
+        model.EntityId.ShouldBe("cust-1");
+        model.Outcome.ShouldBe(AuditOutcome.Success);
+        model.TimestampUtc.ShouldBe(ts);
+        model.StartedAtUtc.ShouldBe(startedAt);
+        model.CompletedAtUtc.ShouldBe(completedAt);
+        model.RequestPayloadHash.ShouldBe("h");
+        model.TenantId.ShouldBe("t");
+        model.UserId.ShouldBe("u");
+        model.IpAddress.ShouldBe("ip");
+        model.UserAgent.ShouldBe("ua");
+        model.RequestPayload.ShouldBe("req");
+        model.ResponsePayload.ShouldBe("resp");
+        model.MetadataJson.ShouldBe("{}");
+        model.IsShredded.ShouldBeFalse();
+        model.TemporalKeyPeriod.ShouldBe("2026-03");
+    }
+
+    #endregion
+
+    #region ReadAuditEntryReadModel
+
+    [Fact]
+    public void ReadAuditEntryReadModel_DefaultValues_AreSensible()
+    {
+        var model = new ReadAuditEntryReadModel();
+
+        model.Id.ShouldBe(Guid.Empty);
+        model.EntityType.ShouldBe(string.Empty);
+        model.EntityId.ShouldBeNull();
+        model.EntityCount.ShouldBe(0);
+        model.CorrelationId.ShouldBeNull();
+        model.TenantId.ShouldBeNull();
+        model.UserId.ShouldBeNull();
+        model.Purpose.ShouldBeNull();
+        model.MetadataJson.ShouldBeNull();
+        model.IsShredded.ShouldBeFalse();
+        model.TemporalKeyPeriod.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void ReadAuditEntryReadModel_CanSetAllProperties()
+    {
+        var id = Guid.NewGuid();
+        var accessed = DateTimeOffset.UtcNow;
+
+        var model = new ReadAuditEntryReadModel
+        {
+            Id = id,
+            EntityType = "Patient",
+            EntityId = "p-1",
+            AccessedAtUtc = accessed,
+            AccessMethod = ReadAccessMethod.Repository,
+            EntityCount = 7,
+            CorrelationId = "c",
+            TenantId = "t",
+            UserId = "u",
+            Purpose = "treatment",
+            MetadataJson = "{}",
+            IsShredded = true,
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        model.Id.ShouldBe(id);
+        model.EntityType.ShouldBe("Patient");
+        model.EntityId.ShouldBe("p-1");
+        model.AccessedAtUtc.ShouldBe(accessed);
+        model.AccessMethod.ShouldBe(ReadAccessMethod.Repository);
+        model.EntityCount.ShouldBe(7);
+        model.CorrelationId.ShouldBe("c");
+        model.TenantId.ShouldBe("t");
+        model.UserId.ShouldBe("u");
+        model.Purpose.ShouldBe("treatment");
+        model.MetadataJson.ShouldBe("{}");
+        model.IsShredded.ShouldBeTrue();
+        model.TemporalKeyPeriod.ShouldBe("2026-03");
+    }
+
+    #endregion
+}

--- a/tests/Encina.UnitTests/AuditMarten/AuditEntryProjectionTests.cs
+++ b/tests/Encina.UnitTests/AuditMarten/AuditEntryProjectionTests.cs
@@ -1,0 +1,233 @@
+using Encina.Audit.Marten;
+using Encina.Audit.Marten.Crypto;
+using Encina.Audit.Marten.Events;
+using Encina.Audit.Marten.Projections;
+using Encina.Security.Audit;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Encina.UnitTests.AuditMarten;
+
+/// <summary>
+/// Unit tests for <see cref="AuditEntryProjection"/> event-to-read-model projection logic.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Provider", "Marten")]
+public sealed class AuditEntryProjectionTests
+{
+    private static ServiceProvider BuildServices(InMemoryTemporalKeyProvider keyProvider, MartenAuditOptions? options = null)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ITemporalKeyProvider>(keyProvider);
+        services.Configure<MartenAuditOptions>(o =>
+        {
+            var cfg = options ?? new MartenAuditOptions();
+            o.TemporalGranularity = cfg.TemporalGranularity;
+            o.EncryptionScope = cfg.EncryptionScope;
+            o.RetentionPeriod = cfg.RetentionPeriod;
+            o.ShreddedPlaceholder = cfg.ShreddedPlaceholder;
+            o.EnableAutoPurge = cfg.EnableAutoPurge;
+            o.PurgeIntervalHours = cfg.PurgeIntervalHours;
+        });
+        services.AddLogging();
+        return services.BuildServiceProvider();
+    }
+
+    private static InMemoryTemporalKeyProvider CreateKeyProvider(FakeTimeProvider? time = null) =>
+        new(time ?? new FakeTimeProvider(new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero)),
+            NullLogger<InMemoryTemporalKeyProvider>.Instance);
+
+    [Fact]
+    public void Constructor_SetsName()
+    {
+        var projection = new AuditEntryProjection();
+        projection.Name.ShouldBe("AuditEntryProjection");
+    }
+
+    [Fact]
+    public async Task Create_WithValidKey_DecryptsPiiFields()
+    {
+        // Arrange
+        var keyProvider = CreateKeyProvider();
+        var keyResult = await keyProvider.GetOrCreateKeyAsync("2026-03");
+        byte[] keyMaterial = null!;
+        string keyId = null!;
+        keyResult.IfRight(k => { keyMaterial = k.KeyMaterial; keyId = k.KeyId; });
+
+        var services = BuildServices(keyProvider);
+        var projection = new AuditEntryProjection();
+
+        var evt = new AuditEntryRecordedEvent
+        {
+            Id = Guid.NewGuid(),
+            CorrelationId = "corr-1",
+            Action = "Update",
+            EntityType = "Order",
+            EntityId = "order-42",
+            Outcome = (int)AuditOutcome.Success,
+            ErrorMessage = null,
+            TimestampUtc = DateTime.UtcNow,
+            StartedAtUtc = DateTimeOffset.UtcNow,
+            CompletedAtUtc = DateTimeOffset.UtcNow.AddMilliseconds(10),
+            RequestPayloadHash = "abc123",
+            TenantId = "tenant-1",
+            EncryptedUserId = EncryptedField.Encrypt("user@example.com", keyMaterial, keyId),
+            EncryptedIpAddress = EncryptedField.Encrypt("192.168.1.1", keyMaterial, keyId),
+            EncryptedUserAgent = EncryptedField.Encrypt("Mozilla/5.0", keyMaterial, keyId),
+            EncryptedRequestPayload = EncryptedField.Encrypt("{}", keyMaterial, keyId),
+            EncryptedResponsePayload = EncryptedField.Encrypt("{\"ok\":true}", keyMaterial, keyId),
+            EncryptedMetadata = EncryptedField.Encrypt("{\"k\":\"v\"}", keyMaterial, keyId),
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        // Act
+        var readModel = await projection.Create(evt, services);
+
+        // Assert
+        readModel.ShouldNotBeNull();
+        readModel.Id.ShouldBe(evt.Id);
+        readModel.CorrelationId.ShouldBe("corr-1");
+        readModel.Action.ShouldBe("Update");
+        readModel.EntityType.ShouldBe("Order");
+        readModel.EntityId.ShouldBe("order-42");
+        readModel.Outcome.ShouldBe(AuditOutcome.Success);
+        readModel.TenantId.ShouldBe("tenant-1");
+        readModel.UserId.ShouldBe("user@example.com");
+        readModel.IpAddress.ShouldBe("192.168.1.1");
+        readModel.UserAgent.ShouldBe("Mozilla/5.0");
+        readModel.RequestPayload.ShouldBe("{}");
+        readModel.ResponsePayload.ShouldBe("{\"ok\":true}");
+        readModel.MetadataJson.ShouldBe("{\"k\":\"v\"}");
+        readModel.IsShredded.ShouldBeFalse();
+        readModel.TemporalKeyPeriod.ShouldBe("2026-03");
+    }
+
+    [Fact]
+    public async Task Create_WithMissingKey_ReturnsShreddedModel()
+    {
+        // Arrange
+        var keyProvider = CreateKeyProvider();
+        // DO NOT create key for "2099-12" - it will be shredded
+        var services = BuildServices(keyProvider);
+        var projection = new AuditEntryProjection();
+
+        // Encrypt using a different key that won't be found
+        var dummyKey = new byte[32];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(dummyKey);
+        var encrypted = EncryptedField.Encrypt("secret", dummyKey, "temporal:2099-12:v1");
+
+        var evt = new AuditEntryRecordedEvent
+        {
+            Id = Guid.NewGuid(),
+            CorrelationId = "corr-x",
+            Action = "Delete",
+            EntityType = "User",
+            EntityId = null,
+            Outcome = (int)AuditOutcome.Failure,
+            ErrorMessage = "denied",
+            TimestampUtc = DateTime.UtcNow,
+            StartedAtUtc = DateTimeOffset.UtcNow,
+            CompletedAtUtc = DateTimeOffset.UtcNow,
+            RequestPayloadHash = null,
+            TenantId = null,
+            EncryptedUserId = encrypted,
+            EncryptedIpAddress = null,
+            EncryptedUserAgent = null,
+            EncryptedRequestPayload = null,
+            EncryptedResponsePayload = null,
+            EncryptedMetadata = null,
+            TemporalKeyPeriod = "2099-12"
+        };
+
+        // Act
+        var readModel = await projection.Create(evt, services);
+
+        // Assert
+        readModel.IsShredded.ShouldBeTrue();
+        readModel.UserId.ShouldBe("[SHREDDED]");
+        readModel.Outcome.ShouldBe(AuditOutcome.Failure);
+        readModel.ErrorMessage.ShouldBe("denied");
+    }
+
+    [Fact]
+    public async Task Create_WithNullEncryptedFields_ReturnsModelWithNulls()
+    {
+        // Arrange
+        var keyProvider = CreateKeyProvider();
+        await keyProvider.GetOrCreateKeyAsync("2026-03");
+        var services = BuildServices(keyProvider);
+        var projection = new AuditEntryProjection();
+
+        var evt = new AuditEntryRecordedEvent
+        {
+            Id = Guid.NewGuid(),
+            CorrelationId = "corr-nulls",
+            Action = "Read",
+            EntityType = "Report",
+            EntityId = null,
+            Outcome = (int)AuditOutcome.Success,
+            ErrorMessage = null,
+            TimestampUtc = DateTime.UtcNow,
+            StartedAtUtc = DateTimeOffset.UtcNow,
+            CompletedAtUtc = DateTimeOffset.UtcNow,
+            RequestPayloadHash = null,
+            TenantId = null,
+            EncryptedUserId = null,
+            EncryptedIpAddress = null,
+            EncryptedUserAgent = null,
+            EncryptedRequestPayload = null,
+            EncryptedResponsePayload = null,
+            EncryptedMetadata = null,
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        // Act
+        var readModel = await projection.Create(evt, services);
+
+        // Assert
+        readModel.UserId.ShouldBeNull();
+        readModel.IpAddress.ShouldBeNull();
+        readModel.UserAgent.ShouldBeNull();
+        readModel.RequestPayload.ShouldBeNull();
+        readModel.ResponsePayload.ShouldBeNull();
+        readModel.MetadataJson.ShouldBeNull();
+        readModel.IsShredded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Create_UsesCustomShreddedPlaceholder()
+    {
+        // Arrange
+        var keyProvider = CreateKeyProvider();
+        var options = new MartenAuditOptions { ShreddedPlaceholder = "<REDACTED>" };
+        var services = BuildServices(keyProvider, options);
+        var projection = new AuditEntryProjection();
+
+        var dummyKey = new byte[32];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(dummyKey);
+        var encrypted = EncryptedField.Encrypt("secret", dummyKey, "temporal:1999-01:v1");
+
+        var evt = new AuditEntryRecordedEvent
+        {
+            Id = Guid.NewGuid(),
+            CorrelationId = "c",
+            Action = "x",
+            EntityType = "E",
+            Outcome = 0,
+            TimestampUtc = DateTime.UtcNow,
+            StartedAtUtc = DateTimeOffset.UtcNow,
+            CompletedAtUtc = DateTimeOffset.UtcNow,
+            EncryptedUserId = encrypted,
+            TemporalKeyPeriod = "1999-01"
+        };
+
+        // Act
+        var readModel = await projection.Create(evt, services);
+
+        // Assert
+        readModel.UserId.ShouldBe("<REDACTED>");
+        readModel.IsShredded.ShouldBeTrue();
+    }
+}

--- a/tests/Encina.UnitTests/AuditMarten/ConfigureMartenAuditProjectionsTests.cs
+++ b/tests/Encina.UnitTests/AuditMarten/ConfigureMartenAuditProjectionsTests.cs
@@ -1,0 +1,30 @@
+using Encina.Audit.Marten.Projections;
+
+namespace Encina.UnitTests.AuditMarten;
+
+/// <summary>
+/// Unit tests for <see cref="ConfigureMartenAuditProjections"/> Marten store option configurator.
+/// </summary>
+/// <remarks>
+/// Only the null-guard path is validated in unit tests. The full Configure path requires a
+/// real Marten store initialization (integration-level) because Marten's projection validation
+/// requires a DocumentStore context that cannot be faked.
+/// </remarks>
+[Trait("Category", "Unit")]
+[Trait("Provider", "Marten")]
+public sealed class ConfigureMartenAuditProjectionsTests
+{
+    [Fact]
+    public void Configure_NullOptions_ThrowsArgumentNullException()
+    {
+        var sut = new ConfigureMartenAuditProjections();
+        Should.Throw<ArgumentNullException>(() => sut.Configure(null!));
+    }
+
+    [Fact]
+    public void Constructor_CreatesInstance()
+    {
+        var sut = new ConfigureMartenAuditProjections();
+        sut.ShouldNotBeNull();
+    }
+}

--- a/tests/Encina.UnitTests/AuditMarten/MartenAuditHealthCheckTests.cs
+++ b/tests/Encina.UnitTests/AuditMarten/MartenAuditHealthCheckTests.cs
@@ -1,0 +1,143 @@
+#pragma warning disable CA2012 // NSubstitute ValueTask stubbing pattern
+
+using Encina.Audit.Marten;
+using Encina.Audit.Marten.Crypto;
+using Encina.Audit.Marten.Health;
+
+using LanguageExt;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+using NSubstitute;
+
+using static LanguageExt.Prelude;
+
+namespace Encina.UnitTests.AuditMarten;
+
+/// <summary>
+/// Unit tests for <see cref="MartenAuditHealthCheck"/> DI-based health check.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Provider", "Marten")]
+public sealed class MartenAuditHealthCheckTests
+{
+    private static readonly HealthCheckContext DummyContext = new()
+    {
+        Registration = new HealthCheckRegistration(
+            MartenAuditHealthCheck.DefaultName,
+            Substitute.For<IHealthCheck>(),
+            HealthStatus.Unhealthy,
+            tags: null)
+    };
+
+    [Fact]
+    public void Constants_DefaultName_IsCorrect()
+    {
+        MartenAuditHealthCheck.DefaultName.ShouldBe("encina-audit-marten");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_NoKeyProviderRegistered_ReturnsUnhealthy()
+    {
+        // Arrange — no ITemporalKeyProvider in DI
+        var services = new ServiceCollection().BuildServiceProvider();
+        var sut = new MartenAuditHealthCheck(services);
+
+        // Act
+        var result = await sut.CheckHealthAsync(DummyContext);
+
+        // Assert
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Description.ShouldNotBeNull();
+        result.Description!.ShouldContain("ITemporalKeyProvider");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_KeyProviderWithActiveKeys_ReturnsHealthy()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero));
+        var keyProvider = new InMemoryTemporalKeyProvider(timeProvider, NullLogger<InMemoryTemporalKeyProvider>.Instance);
+        await keyProvider.GetOrCreateKeyAsync("2026-03");
+
+        services.AddSingleton<ITemporalKeyProvider>(keyProvider);
+        var sp = services.BuildServiceProvider();
+        var sut = new MartenAuditHealthCheck(sp);
+
+        // Act
+        var result = await sut.CheckHealthAsync(DummyContext);
+
+        // Assert
+        result.Status.ShouldBe(HealthStatus.Healthy);
+        result.Data.ShouldContainKey("active_key_count");
+        result.Data.ShouldContainKey("provider_type");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_KeyProviderWithNoKeys_ReturnsDegraded()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var timeProvider = new FakeTimeProvider();
+        var keyProvider = new InMemoryTemporalKeyProvider(timeProvider, NullLogger<InMemoryTemporalKeyProvider>.Instance);
+
+        services.AddSingleton<ITemporalKeyProvider>(keyProvider);
+        var sp = services.BuildServiceProvider();
+        var sut = new MartenAuditHealthCheck(sp);
+
+        // Act
+        var result = await sut.CheckHealthAsync(DummyContext);
+
+        // Assert
+        result.Status.ShouldBe(HealthStatus.Degraded);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_KeyProviderReturnsLeft_ReturnsDegraded()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var keyProvider = Substitute.For<ITemporalKeyProvider>();
+        keyProvider.GetActiveKeysAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<Either<EncinaError, IReadOnlyList<TemporalKeyInfo>>>(
+                Left<EncinaError, IReadOnlyList<TemporalKeyInfo>>(
+                    MartenAuditErrors.StoreUnavailable("unreachable"))));
+
+        services.AddSingleton(keyProvider);
+        var sp = services.BuildServiceProvider();
+        var sut = new MartenAuditHealthCheck(sp);
+
+        // Act
+        var result = await sut.CheckHealthAsync(DummyContext);
+
+        // Assert
+        result.Status.ShouldBe(HealthStatus.Degraded);
+        result.Data.ShouldContainKey("error");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_KeyProviderThrows_ReturnsUnhealthy()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var keyProvider = Substitute.For<ITemporalKeyProvider>();
+        keyProvider.GetActiveKeysAsync(Arg.Any<CancellationToken>())
+            .Returns<ValueTask<Either<EncinaError, IReadOnlyList<TemporalKeyInfo>>>>(
+                _ => throw new InvalidOperationException("boom"));
+
+        services.AddSingleton(keyProvider);
+        var sp = services.BuildServiceProvider();
+        var sut = new MartenAuditHealthCheck(sp);
+
+        // Act
+        var result = await sut.CheckHealthAsync(DummyContext);
+
+        // Assert
+        result.Status.ShouldBe(HealthStatus.Unhealthy);
+        result.Exception.ShouldNotBeNull();
+    }
+}

--- a/tests/Encina.UnitTests/AuditMarten/MartenAuditRetentionServiceTests.cs
+++ b/tests/Encina.UnitTests/AuditMarten/MartenAuditRetentionServiceTests.cs
@@ -1,0 +1,171 @@
+#pragma warning disable CA2012 // NSubstitute ValueTask stubbing pattern
+
+using Encina.Audit.Marten;
+using Encina.Security.Audit;
+
+using LanguageExt;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+
+using NSubstitute;
+
+using static LanguageExt.Prelude;
+
+namespace Encina.UnitTests.AuditMarten;
+
+/// <summary>
+/// Unit tests for <see cref="MartenAuditRetentionService"/> background crypto-shredding cycle.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Provider", "Marten")]
+public sealed class MartenAuditRetentionServiceTests
+{
+    private static ServiceProvider BuildServiceProvider(IAuditStore auditStore)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(auditStore);
+        services.AddLogging();
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void Constructor_NullServiceProvider_Throws()
+    {
+        var options = Options.Create(new MartenAuditOptions());
+        Should.Throw<ArgumentNullException>(() => new MartenAuditRetentionService(
+            null!,
+            options,
+            TimeProvider.System,
+            NullLogger<MartenAuditRetentionService>.Instance));
+    }
+
+    [Fact]
+    public void Constructor_NullOptions_Throws()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        Should.Throw<ArgumentNullException>(() => new MartenAuditRetentionService(
+            sp,
+            null!,
+            TimeProvider.System,
+            NullLogger<MartenAuditRetentionService>.Instance));
+    }
+
+    [Fact]
+    public void Constructor_NullTimeProvider_Throws()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var options = Options.Create(new MartenAuditOptions());
+        Should.Throw<ArgumentNullException>(() => new MartenAuditRetentionService(
+            sp,
+            options,
+            null!,
+            NullLogger<MartenAuditRetentionService>.Instance));
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var options = Options.Create(new MartenAuditOptions());
+        Should.Throw<ArgumentNullException>(() => new MartenAuditRetentionService(
+            sp,
+            options,
+            TimeProvider.System,
+            null!));
+    }
+
+    [Fact]
+    public void Constructor_ValidArgs_DoesNotThrow()
+    {
+        var auditStore = Substitute.For<IAuditStore>();
+        var sp = BuildServiceProvider(auditStore);
+        var options = Options.Create(new MartenAuditOptions
+        {
+            RetentionPeriod = TimeSpan.FromDays(90),
+            PurgeIntervalHours = 6
+        });
+
+        var sut = new MartenAuditRetentionService(
+            sp,
+            options,
+            TimeProvider.System,
+            NullLogger<MartenAuditRetentionService>.Instance);
+
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task StartAsync_CancelledImmediately_DoesNotThrow()
+    {
+        var auditStore = Substitute.For<IAuditStore>();
+        auditStore.PurgeEntriesAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<Either<EncinaError, int>>(Right<EncinaError, int>(0)));
+
+        var sp = BuildServiceProvider(auditStore);
+        var options = Options.Create(new MartenAuditOptions
+        {
+            RetentionPeriod = TimeSpan.FromDays(30),
+            PurgeIntervalHours = 24
+        });
+
+        var sut = new MartenAuditRetentionService(
+            sp,
+            options,
+            TimeProvider.System,
+            NullLogger<MartenAuditRetentionService>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Should complete quickly due to cancellation - BackgroundService wraps ExecuteAsync
+        await sut.StartAsync(cts.Token);
+        await sut.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StopAsync_WithoutStart_DoesNotThrow()
+    {
+        var auditStore = Substitute.For<IAuditStore>();
+        var sp = BuildServiceProvider(auditStore);
+        var options = Options.Create(new MartenAuditOptions());
+
+        var sut = new MartenAuditRetentionService(
+            sp,
+            options,
+            new FakeTimeProvider(),
+            NullLogger<MartenAuditRetentionService>.Instance);
+
+        await sut.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartAsync_ShortCancellation_StopsCleanly()
+    {
+        var auditStore = Substitute.For<IAuditStore>();
+        auditStore.PurgeEntriesAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<Either<EncinaError, int>>(Right<EncinaError, int>(5)));
+
+        var sp = BuildServiceProvider(auditStore);
+        var options = Options.Create(new MartenAuditOptions
+        {
+            PurgeIntervalHours = 24,
+            RetentionPeriod = TimeSpan.FromDays(365)
+        });
+
+        var sut = new MartenAuditRetentionService(
+            sp,
+            options,
+            TimeProvider.System,
+            NullLogger<MartenAuditRetentionService>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        await sut.StartAsync(cts.Token);
+
+        await Task.Delay(100);
+
+        await sut.StopAsync(CancellationToken.None);
+    }
+}

--- a/tests/Encina.UnitTests/AuditMarten/ReadAuditEntryProjectionTests.cs
+++ b/tests/Encina.UnitTests/AuditMarten/ReadAuditEntryProjectionTests.cs
@@ -1,0 +1,163 @@
+using Encina.Audit.Marten;
+using Encina.Audit.Marten.Crypto;
+using Encina.Audit.Marten.Events;
+using Encina.Audit.Marten.Projections;
+using Encina.Security.Audit;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Encina.UnitTests.AuditMarten;
+
+/// <summary>
+/// Unit tests for <see cref="ReadAuditEntryProjection"/> read-audit event projection logic.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Provider", "Marten")]
+public sealed class ReadAuditEntryProjectionTests
+{
+    private static ServiceProvider BuildServices(InMemoryTemporalKeyProvider keyProvider, MartenAuditOptions? options = null)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ITemporalKeyProvider>(keyProvider);
+        services.Configure<MartenAuditOptions>(o =>
+        {
+            var cfg = options ?? new MartenAuditOptions();
+            o.ShreddedPlaceholder = cfg.ShreddedPlaceholder;
+        });
+        services.AddLogging();
+        return services.BuildServiceProvider();
+    }
+
+    private static InMemoryTemporalKeyProvider CreateKeyProvider() =>
+        new(new FakeTimeProvider(new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero)),
+            NullLogger<InMemoryTemporalKeyProvider>.Instance);
+
+    [Fact]
+    public void Constructor_SetsName()
+    {
+        var projection = new ReadAuditEntryProjection();
+        projection.Name.ShouldBe("ReadAuditEntryProjection");
+    }
+
+    [Fact]
+    public async Task Create_WithValidKey_DecryptsPiiFields()
+    {
+        // Arrange
+        var keyProvider = CreateKeyProvider();
+        var keyResult = await keyProvider.GetOrCreateKeyAsync("2026-03");
+        byte[] keyMaterial = null!;
+        string keyId = null!;
+        keyResult.IfRight(k => { keyMaterial = k.KeyMaterial; keyId = k.KeyId; });
+
+        var services = BuildServices(keyProvider);
+        var projection = new ReadAuditEntryProjection();
+
+        var evt = new ReadAuditEntryRecordedEvent
+        {
+            Id = Guid.NewGuid(),
+            EntityType = "Patient",
+            EntityId = "patient-42",
+            AccessedAtUtc = DateTimeOffset.UtcNow,
+            AccessMethod = (int)ReadAccessMethod.Repository,
+            EntityCount = 1,
+            CorrelationId = "corr-r",
+            TenantId = "hospital-1",
+            EncryptedUserId = EncryptedField.Encrypt("doctor@hospital", keyMaterial, keyId),
+            EncryptedPurpose = EncryptedField.Encrypt("treatment review", keyMaterial, keyId),
+            EncryptedMetadata = EncryptedField.Encrypt("{\"dept\":\"oncology\"}", keyMaterial, keyId),
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        // Act
+        var readModel = await projection.Create(evt, services);
+
+        // Assert
+        readModel.ShouldNotBeNull();
+        readModel.Id.ShouldBe(evt.Id);
+        readModel.EntityType.ShouldBe("Patient");
+        readModel.EntityId.ShouldBe("patient-42");
+        readModel.AccessMethod.ShouldBe(ReadAccessMethod.Repository);
+        readModel.EntityCount.ShouldBe(1);
+        readModel.CorrelationId.ShouldBe("corr-r");
+        readModel.TenantId.ShouldBe("hospital-1");
+        readModel.UserId.ShouldBe("doctor@hospital");
+        readModel.Purpose.ShouldBe("treatment review");
+        readModel.MetadataJson.ShouldBe("{\"dept\":\"oncology\"}");
+        readModel.IsShredded.ShouldBeFalse();
+        readModel.TemporalKeyPeriod.ShouldBe("2026-03");
+    }
+
+    [Fact]
+    public async Task Create_WithMissingKey_ReturnsShreddedModel()
+    {
+        // Arrange
+        var keyProvider = CreateKeyProvider();
+        var services = BuildServices(keyProvider);
+        var projection = new ReadAuditEntryProjection();
+
+        var dummyKey = new byte[32];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(dummyKey);
+        var encrypted = EncryptedField.Encrypt("user", dummyKey, "temporal:2099-12:v1");
+
+        var evt = new ReadAuditEntryRecordedEvent
+        {
+            Id = Guid.NewGuid(),
+            EntityType = "Record",
+            EntityId = null,
+            AccessedAtUtc = DateTimeOffset.UtcNow,
+            AccessMethod = (int)ReadAccessMethod.DirectQuery,
+            EntityCount = 0,
+            CorrelationId = null,
+            TenantId = null,
+            EncryptedUserId = encrypted,
+            EncryptedPurpose = null,
+            EncryptedMetadata = null,
+            TemporalKeyPeriod = "2099-12"
+        };
+
+        // Act
+        var readModel = await projection.Create(evt, services);
+
+        // Assert
+        readModel.IsShredded.ShouldBeTrue();
+        readModel.UserId.ShouldBe("[SHREDDED]");
+        readModel.AccessMethod.ShouldBe(ReadAccessMethod.DirectQuery);
+    }
+
+    [Fact]
+    public async Task Create_WithNullEncryptedFields_ReturnsModelWithNulls()
+    {
+        // Arrange
+        var keyProvider = CreateKeyProvider();
+        await keyProvider.GetOrCreateKeyAsync("2026-03");
+        var services = BuildServices(keyProvider);
+        var projection = new ReadAuditEntryProjection();
+
+        var evt = new ReadAuditEntryRecordedEvent
+        {
+            Id = Guid.NewGuid(),
+            EntityType = "Log",
+            EntityId = null,
+            AccessedAtUtc = DateTimeOffset.UtcNow,
+            AccessMethod = (int)ReadAccessMethod.Export,
+            EntityCount = 10,
+            EncryptedUserId = null,
+            EncryptedPurpose = null,
+            EncryptedMetadata = null,
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        // Act
+        var readModel = await projection.Create(evt, services);
+
+        // Assert
+        readModel.UserId.ShouldBeNull();
+        readModel.Purpose.ShouldBeNull();
+        readModel.MetadataJson.ShouldBeNull();
+        readModel.IsShredded.ShouldBeFalse();
+        readModel.EntityCount.ShouldBe(10);
+        readModel.AccessMethod.ShouldBe(ReadAccessMethod.Export);
+    }
+}


### PR DESCRIPTION
## Summary
Close test coverage gaps for `Encina.Audit.Marten` (UNIT -180 / GUARD -160).

New tests instantiate real package code:
- **Unit** (AuditMarten/): projection Create branches, retention service lifecycle, health check states, event/read-model POCOs
- **Guard** (AuditMarten/): projection constructors + shredded paths, every MartenAuditErrors factory, TemporalPeriodHelper branches, options defaults

## Test plan
- [x] `dotnet build tests/Encina.UnitTests/Encina.UnitTests.csproj` — 0 warnings
- [x] `dotnet build tests/Encina.GuardTests/Encina.GuardTests.csproj` — 0 warnings  
- [x] `dotnet test --filter 'FullyQualifiedName~AuditMarten'` Unit: 114 passed, 1 skipped
- [x] `dotnet test --filter 'FullyQualifiedName~AuditMarten'` Guard: 77 passed
- [ ] CI Full measures coverage after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Se han añadido nuevas suites de pruebas exhaustivas para validar la funcionalidad de auditoría Marten, cubriendo modelos de eventos, proyecciones de lectura, opciones de configuración, manejo de periodos temporales, encriptación y verificación de salud del sistema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->