### PR TITLE
test(cli): close UNIT and GUARD coverage gaps

### DIFF
--- a/tests/Encina.GuardTests/CLI/OptionsRecordsGuardTests.cs
+++ b/tests/Encina.GuardTests/CLI/OptionsRecordsGuardTests.cs
@@ -1,0 +1,208 @@
+using Encina.Cli.Services;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Encina.GuardTests.CLI;
+
+/// <summary>
+/// Guard tests for <see cref="HandlerOptions"/>, <see cref="QueryOptions"/>,
+/// <see cref="SagaOptions"/>, <see cref="NotificationOptions"/>,
+/// <see cref="ProjectOptions"/>, and <see cref="GenerationResult"/>/<see cref="ScaffoldResult"/>
+/// factories — ensures the public surface is stable and exercises assignment paths.
+/// </summary>
+public class OptionsRecordsGuardTests
+{
+    [Fact]
+    public void HandlerOptions_Defaults_AreAssignable()
+    {
+        var options = new HandlerOptions
+        {
+            Name = "DoThing",
+            OutputDirectory = "/tmp"
+        };
+
+        options.Name.ShouldBe("DoThing");
+        options.ResponseType.ShouldBe("Unit");
+        options.OutputDirectory.ShouldBe("/tmp");
+        options.Namespace.ShouldBeNull();
+    }
+
+    [Fact]
+    public void HandlerOptions_AllPropertiesSettable()
+    {
+        var options = new HandlerOptions
+        {
+            Name = "N",
+            ResponseType = "R",
+            OutputDirectory = "O",
+            Namespace = "NS"
+        };
+
+        options.Name.ShouldBe("N");
+        options.ResponseType.ShouldBe("R");
+        options.OutputDirectory.ShouldBe("O");
+        options.Namespace.ShouldBe("NS");
+    }
+
+    [Fact]
+    public void QueryOptions_AllPropertiesSettable()
+    {
+        var options = new QueryOptions
+        {
+            Name = "GetX",
+            ResponseType = "Dto",
+            OutputDirectory = "O",
+            Namespace = "NS"
+        };
+
+        options.Name.ShouldBe("GetX");
+        options.ResponseType.ShouldBe("Dto");
+        options.OutputDirectory.ShouldBe("O");
+        options.Namespace.ShouldBe("NS");
+    }
+
+    [Fact]
+    public void SagaOptions_AllPropertiesSettable()
+    {
+        var options = new SagaOptions
+        {
+            Name = "Order",
+            Steps = ["A", "B"],
+            OutputDirectory = "O",
+            Namespace = "NS"
+        };
+
+        options.Name.ShouldBe("Order");
+        options.Steps.Count.ShouldBe(2);
+        options.OutputDirectory.ShouldBe("O");
+        options.Namespace.ShouldBe("NS");
+    }
+
+    [Fact]
+    public void NotificationOptions_AllPropertiesSettable()
+    {
+        var options = new NotificationOptions
+        {
+            Name = "OrderCreated",
+            OutputDirectory = "O",
+            Namespace = "NS"
+        };
+
+        options.Name.ShouldBe("OrderCreated");
+        options.OutputDirectory.ShouldBe("O");
+        options.Namespace.ShouldBe("NS");
+    }
+
+    [Fact]
+    public void ProjectOptions_DefaultsAndOptionals()
+    {
+        var options = new ProjectOptions
+        {
+            Template = "api",
+            Name = "Sample",
+            OutputDirectory = "/tmp/sample"
+        };
+
+        options.Template.ShouldBe("api");
+        options.Name.ShouldBe("Sample");
+        options.OutputDirectory.ShouldBe("/tmp/sample");
+        options.Database.ShouldBeNull();
+        options.Caching.ShouldBeNull();
+        options.Transport.ShouldBeNull();
+        options.Force.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ProjectOptions_AllPropertiesSettable()
+    {
+        var options = new ProjectOptions
+        {
+            Template = "worker",
+            Name = "Full",
+            OutputDirectory = "/tmp",
+            Database = "sqlserver",
+            Caching = "redis",
+            Transport = "kafka",
+            Force = true
+        };
+
+        options.Template.ShouldBe("worker");
+        options.Database.ShouldBe("sqlserver");
+        options.Caching.ShouldBe("redis");
+        options.Transport.ShouldBe("kafka");
+        options.Force.ShouldBeTrue();
+    }
+
+    // ─── Result factories ───
+
+    [Fact]
+    public void ScaffoldResult_Ok_HoldsFiles()
+    {
+        var files = new[] { "a.cs", "b.cs" };
+        var result = ScaffoldResult.Ok(files);
+
+        result.Success.ShouldBeTrue();
+        result.ErrorMessage.ShouldBeNull();
+        result.GeneratedFiles.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void ScaffoldResult_Error_HoldsMessage()
+    {
+        var result = ScaffoldResult.Error("oops");
+
+        result.Success.ShouldBeFalse();
+        result.ErrorMessage.ShouldBe("oops");
+        result.GeneratedFiles.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GenerationResult_Ok_HoldsFiles()
+    {
+        var files = new[] { "x.cs" };
+        var result = GenerationResult.Ok(files);
+
+        result.Success.ShouldBeTrue();
+        result.ErrorMessage.ShouldBeNull();
+        result.GeneratedFiles.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void GenerationResult_Error_HoldsMessage()
+    {
+        var result = GenerationResult.Error("bad");
+
+        result.Success.ShouldBeFalse();
+        result.ErrorMessage.ShouldBe("bad");
+        result.GeneratedFiles.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void PackageResult_Ok_HasNoError()
+    {
+        var result = PackageResult.Ok();
+
+        result.Success.ShouldBeTrue();
+        result.ErrorMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public void PackageResult_Error_HoldsMessage()
+    {
+        var result = PackageResult.Error("err");
+
+        result.Success.ShouldBeFalse();
+        result.ErrorMessage.ShouldBe("err");
+    }
+
+    [Fact]
+    public void InstalledPackage_PropertiesAssignable()
+    {
+        var pkg = new InstalledPackage { Name = "Encina", Version = "1.0" };
+
+        pkg.Name.ShouldBe("Encina");
+        pkg.Version.ShouldBe("1.0");
+    }
+}

--- a/tests/Encina.GuardTests/CLI/StrykerOptionsGuardTests.cs
+++ b/tests/Encina.GuardTests/CLI/StrykerOptionsGuardTests.cs
@@ -1,0 +1,123 @@
+using Encina.Cli.Services;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Encina.GuardTests.CLI;
+
+/// <summary>
+/// Guard tests for <see cref="StrykerOptions"/> and <see cref="CodeGenerator.GenerateStrykerConfigAsync"/>.
+/// </summary>
+public class StrykerOptionsGuardTests
+{
+    [Fact]
+    public void StrykerOptions_Defaults_AreSensible()
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "src/X/X.csproj",
+            OutputDirectory = "."
+        };
+
+        options.ThresholdHigh.ShouldBe(80);
+        options.ThresholdLow.ShouldBe(60);
+        options.ThresholdBreak.ShouldBe(50);
+        options.UseAdvanced.ShouldBeFalse();
+        options.TestProjects.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void StrykerOptions_CanSetAllProperties()
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "p",
+            OutputDirectory = "o",
+            ThresholdHigh = 90,
+            ThresholdLow = 70,
+            ThresholdBreak = 55,
+            UseAdvanced = true,
+            TestProjects = ["a", "b"]
+        };
+
+        options.ProjectPath.ShouldBe("p");
+        options.OutputDirectory.ShouldBe("o");
+        options.ThresholdHigh.ShouldBe(90);
+        options.ThresholdLow.ShouldBe(70);
+        options.ThresholdBreak.ShouldBe(55);
+        options.UseAdvanced.ShouldBeTrue();
+        options.TestProjects.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GenerateStrykerConfigAsync_NullOptions_ThrowsArgumentNullException()
+    {
+        var act = () => CodeGenerator.GenerateStrykerConfigAsync(null!);
+        (await Should.ThrowAsync<ArgumentNullException>(act)).ParamName.ShouldBe("options");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GenerateStrykerConfigAsync_InvalidProjectPath_Throws(string? project)
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = project!,
+            OutputDirectory = Path.GetTempPath()
+        };
+
+        await Should.ThrowAsync<ArgumentException>(() => CodeGenerator.GenerateStrykerConfigAsync(options));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GenerateStrykerConfigAsync_InvalidOutputDirectory_Throws(string? output)
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "src/MyApp/MyApp.csproj",
+            OutputDirectory = output!
+        };
+
+        await Should.ThrowAsync<ArgumentException>(() => CodeGenerator.GenerateStrykerConfigAsync(options));
+    }
+
+    // Invalid threshold combinations return an error result (not an exception).
+
+    [Theory]
+    [InlineData(80, 60, 70)] // break > low
+    [InlineData(60, 80, 50)] // low > high
+    [InlineData(80, 60, -1)] // break < 0
+    [InlineData(101, 60, 50)] // high > 100
+    public async Task GenerateStrykerConfigAsync_InvalidThresholds_ReturnsError(int high, int low, int @break)
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "src/X/X.csproj",
+            OutputDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()),
+            ThresholdHigh = high,
+            ThresholdLow = low,
+            ThresholdBreak = @break
+        };
+
+        Directory.CreateDirectory(options.OutputDirectory);
+        try
+        {
+            var result = await CodeGenerator.GenerateStrykerConfigAsync(options);
+            result.Success.ShouldBeFalse();
+            result.ErrorMessage!.ShouldContain("Invalid thresholds");
+        }
+        finally
+        {
+            if (Directory.Exists(options.OutputDirectory))
+            {
+                Directory.Delete(options.OutputDirectory, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/Encina.UnitTests/Cli/Commands/AddCommandTests.cs
+++ b/tests/Encina.UnitTests/Cli/Commands/AddCommandTests.cs
@@ -1,0 +1,194 @@
+using System.CommandLine;
+
+using Encina.Cli.Commands;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Encina.UnitTests.Cli.Commands;
+
+/// <summary>
+/// Unit tests for <see cref="AddCommand"/> exercising the System.CommandLine subcommand
+/// tree, aliases, and provider → package mapping switch statements.
+/// </summary>
+/// <remarks>
+/// The <c>SetAction</c> delegates ultimately call <c>PackageManager.AddPackagesAsync</c>, which
+/// tries to locate a <c>.csproj</c> in the current working directory. In the unit test runner
+/// process the current directory does contain <c>Encina.UnitTests.csproj</c>, so the execution
+/// path reaches <c>dotnet add package ...</c>. We intentionally only exercise the command graph
+/// construction for the mapping paths, and use <b>unknown providers</b> to drive the error
+/// branches without touching the network / filesystem.
+/// </remarks>
+public class AddCommandTests
+{
+    private static RootCommand BuildRoot()
+    {
+        var root = new RootCommand("test");
+        root.Subcommands.Add(AddCommand.Create());
+        return root;
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandWithAllSubcommands()
+    {
+        var command = AddCommand.Create();
+
+        command.Name.ShouldBe("add");
+        command.Subcommands.Count.ShouldBe(6);
+        command.Subcommands.ShouldContain(c => c.Name == "caching");
+        command.Subcommands.ShouldContain(c => c.Name == "database");
+        command.Subcommands.ShouldContain(c => c.Name == "transport");
+        command.Subcommands.ShouldContain(c => c.Name == "validation");
+        command.Subcommands.ShouldContain(c => c.Name == "resilience");
+        command.Subcommands.ShouldContain(c => c.Name == "observability");
+    }
+
+    [Fact]
+    public void Create_CachingCommand_HasCacheAlias()
+    {
+        var add = AddCommand.Create();
+        var caching = add.Subcommands.First(c => c.Name == "caching");
+        caching.Aliases.ShouldContain("cache");
+    }
+
+    [Fact]
+    public void Create_DatabaseCommand_HasDbAlias()
+    {
+        var add = AddCommand.Create();
+        var db = add.Subcommands.First(c => c.Name == "database");
+        db.Aliases.ShouldContain("db");
+    }
+
+    [Fact]
+    public void Create_TransportCommand_HasMessagingAlias()
+    {
+        var add = AddCommand.Create();
+        var transport = add.Subcommands.First(c => c.Name == "transport");
+        transport.Aliases.ShouldContain("messaging");
+    }
+
+    [Fact]
+    public void Create_ObservabilityCommand_HasOtelAlias()
+    {
+        var add = AddCommand.Create();
+        var otel = add.Subcommands.First(c => c.Name == "observability");
+        otel.Aliases.ShouldContain("otel");
+    }
+
+    // ─── Error branches: unknown providers drive each switch _ => null path ───
+
+    [Theory]
+    [InlineData("add", "caching", "nosuchprovider")]
+    [InlineData("add", "database", "nosuchdb")]
+    [InlineData("add", "transport", "nosuchtransport")]
+    [InlineData("add", "validation", "nosuchvalidator")]
+    [InlineData("add", "resilience", "nosuchresilience")]
+    public async Task Invoke_UnknownProvider_ReturnsErrorExitCode(params string[] args)
+    {
+        var root = BuildRoot();
+        var parseResult = root.Parse(args);
+
+        var exitCode = await parseResult.InvokeAsync();
+
+        exitCode.ShouldBe(1);
+    }
+
+    // ─── Parser-level: valid mapping reaches the execute branch ───
+
+    [Theory]
+    [InlineData("add", "caching", "memory")]
+    [InlineData("add", "caching", "redis")]
+    [InlineData("add", "caching", "valkey")]
+    [InlineData("add", "caching", "garnet")]
+    [InlineData("add", "caching", "dragonfly")]
+    [InlineData("add", "caching", "keydb")]
+    [InlineData("add", "caching", "hybrid")]
+    public void Parse_CachingProviders_SucceedsAtArgumentLayer(params string[] args)
+    {
+        var root = BuildRoot();
+        var parseResult = root.Parse(args);
+
+        parseResult.Errors.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("add", "database", "efcore")]
+    [InlineData("add", "database", "entityframeworkcore")]
+    [InlineData("add", "database", "dapper-sqlserver")]
+    [InlineData("add", "database", "dapper-postgresql")]
+    [InlineData("add", "database", "dapper-postgres")]
+    [InlineData("add", "database", "dapper-mysql")]
+    [InlineData("add", "database", "dapper-sqlite")]
+    [InlineData("add", "database", "dapper-oracle")]
+    [InlineData("add", "database", "ado-sqlserver")]
+    [InlineData("add", "database", "ado-postgresql")]
+    [InlineData("add", "database", "ado-postgres")]
+    [InlineData("add", "database", "ado-mysql")]
+    [InlineData("add", "database", "ado-sqlite")]
+    [InlineData("add", "database", "ado-oracle")]
+    [InlineData("add", "database", "mongodb")]
+    [InlineData("add", "database", "marten")]
+    public void Parse_DatabaseProviders_SucceedsAtArgumentLayer(params string[] args)
+    {
+        var root = BuildRoot();
+        var parseResult = root.Parse(args);
+
+        parseResult.Errors.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("add", "transport", "rabbitmq")]
+    [InlineData("add", "transport", "kafka")]
+    [InlineData("add", "transport", "azureservicebus")]
+    [InlineData("add", "transport", "servicebus")]
+    [InlineData("add", "transport", "sqs")]
+    [InlineData("add", "transport", "amazonsqs")]
+    [InlineData("add", "transport", "nats")]
+    [InlineData("add", "transport", "mqtt")]
+    [InlineData("add", "transport", "signalr")]
+    [InlineData("add", "transport", "redis")]
+    [InlineData("add", "transport", "redis-pubsub")]
+    public void Parse_TransportProviders_SucceedsAtArgumentLayer(params string[] args)
+    {
+        var root = BuildRoot();
+        var parseResult = root.Parse(args);
+
+        parseResult.Errors.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("add", "validation", "fluentvalidation")]
+    [InlineData("add", "validation", "fluent")]
+    [InlineData("add", "validation", "dataannotations")]
+    [InlineData("add", "validation", "annotations")]
+    [InlineData("add", "validation", "minivalidator")]
+    [InlineData("add", "validation", "mini")]
+    public void Parse_ValidationProviders_SucceedsAtArgumentLayer(params string[] args)
+    {
+        var root = BuildRoot();
+        var parseResult = root.Parse(args);
+
+        parseResult.Errors.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("add", "resilience", "polly")]
+    [InlineData("add", "resilience", "standard")]
+    public void Parse_ResilienceProviders_SucceedsAtArgumentLayer(params string[] args)
+    {
+        var root = BuildRoot();
+        var parseResult = root.Parse(args);
+
+        parseResult.Errors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Parse_Observability_NoSubArgument_SucceedsAtArgumentLayer()
+    {
+        var root = BuildRoot();
+        var parseResult = root.Parse(["add", "observability"]);
+
+        parseResult.Errors.ShouldBeEmpty();
+    }
+}

--- a/tests/Encina.UnitTests/Cli/Commands/GenerateCommandTests.cs
+++ b/tests/Encina.UnitTests/Cli/Commands/GenerateCommandTests.cs
@@ -1,0 +1,261 @@
+using System.CommandLine;
+
+using Encina.Cli.Commands;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Encina.UnitTests.Cli.Commands;
+
+/// <summary>
+/// Unit tests for <see cref="GenerateCommand"/> subcommand graph and end-to-end
+/// invocations through <see cref="CodeGenerator"/>.
+/// </summary>
+public class GenerateCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public GenerateCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"encina-cli-gen-tests-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private static RootCommand BuildRoot()
+    {
+        var root = new RootCommand("test");
+        root.Subcommands.Add(GenerateCommand.Create());
+        return root;
+    }
+
+    [Fact]
+    public void Create_HasExpectedSubcommandsAndAlias()
+    {
+        var command = GenerateCommand.Create();
+
+        command.Name.ShouldBe("generate");
+        command.Aliases.ShouldContain("g");
+        command.Subcommands.Count.ShouldBe(5);
+        command.Subcommands.ShouldContain(c => c.Name == "handler");
+        command.Subcommands.ShouldContain(c => c.Name == "query");
+        command.Subcommands.ShouldContain(c => c.Name == "saga");
+        command.Subcommands.ShouldContain(c => c.Name == "notification");
+        command.Subcommands.ShouldContain(c => c.Name == "stryker");
+    }
+
+    [Fact]
+    public void Create_HandlerCommand_HasAliases()
+    {
+        var gen = GenerateCommand.Create();
+        var handler = gen.Subcommands.First(c => c.Name == "handler");
+        handler.Aliases.ShouldContain("h");
+        handler.Aliases.ShouldContain("command");
+    }
+
+    [Fact]
+    public void Create_NotificationCommand_HasAliases()
+    {
+        var gen = GenerateCommand.Create();
+        var n = gen.Subcommands.First(c => c.Name == "notification");
+        n.Aliases.ShouldContain("n");
+        n.Aliases.ShouldContain("event");
+    }
+
+    [Fact]
+    public async Task Invoke_Handler_DefaultResponse_GeneratesFiles()
+    {
+        var root = BuildRoot();
+        var exitCode = await root.Parse([
+            "generate", "handler", "CreateOrder",
+            "--output", _tempDir,
+            "--namespace", "MyApp.Commands"
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        File.Exists(Path.Combine(_tempDir, "CreateOrder.cs")).ShouldBeTrue();
+        File.Exists(Path.Combine(_tempDir, "CreateOrderHandler.cs")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Invoke_Handler_WithResponse_GeneratesTypedHandler()
+    {
+        var root = BuildRoot();
+        var exitCode = await root.Parse([
+            "generate", "handler", "CreateOrder",
+            "--response", "OrderId",
+            "--output", _tempDir,
+            "--namespace", "MyApp.Commands"
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        var content = await File.ReadAllTextAsync(Path.Combine(_tempDir, "CreateOrder.cs"));
+        content.ShouldContain("ICommand<OrderId>");
+    }
+
+    [Fact]
+    public async Task Invoke_Query_GeneratesFiles()
+    {
+        var root = BuildRoot();
+        var exitCode = await root.Parse([
+            "generate", "query", "GetOrderById",
+            "--response", "OrderDto",
+            "--output", _tempDir,
+            "--namespace", "MyApp.Queries"
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        File.Exists(Path.Combine(_tempDir, "GetOrderById.cs")).ShouldBeTrue();
+        File.Exists(Path.Combine(_tempDir, "GetOrderByIdHandler.cs")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Invoke_Saga_GeneratesFiles()
+    {
+        var root = BuildRoot();
+        var exitCode = await root.Parse([
+            "generate", "saga", "OrderProcessing",
+            "--steps", "Create,Pay,Ship",
+            "--output", _tempDir,
+            "--namespace", "MyApp.Sagas"
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        File.Exists(Path.Combine(_tempDir, "OrderProcessingSaga.cs")).ShouldBeTrue();
+        File.Exists(Path.Combine(_tempDir, "OrderProcessingData.cs")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Invoke_Saga_InvalidSteps_ReturnsOne()
+    {
+        var root = BuildRoot();
+        // Comma only → split with RemoveEmptyEntries yields 0 steps → generator error
+        var exitCode = await root.Parse([
+            "generate", "saga", "Bad",
+            "--steps", ",",
+            "--output", _tempDir
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Invoke_Notification_GeneratesFiles()
+    {
+        var root = BuildRoot();
+        var exitCode = await root.Parse([
+            "generate", "notification", "OrderCreated",
+            "--output", _tempDir,
+            "--namespace", "MyApp.Events"
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        File.Exists(Path.Combine(_tempDir, "OrderCreated.cs")).ShouldBeTrue();
+        File.Exists(Path.Combine(_tempDir, "OrderCreatedHandler.cs")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Invoke_Stryker_Basic_GeneratesConfig()
+    {
+        var root = BuildRoot();
+        var exitCode = await root.Parse([
+            "generate", "stryker",
+            "--project", "src/MyApp/MyApp.csproj",
+            "--output", _tempDir
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        File.Exists(Path.Combine(_tempDir, "stryker-config.json")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Invoke_Stryker_Advanced_GeneratesConfig()
+    {
+        var root = BuildRoot();
+        var exitCode = await root.Parse([
+            "generate", "stryker",
+            "--project", "src/MyApp/MyApp.csproj",
+            "--output", _tempDir,
+            "--advanced"
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        var content = await File.ReadAllTextAsync(Path.Combine(_tempDir, "stryker-config.json"));
+        content.ShouldContain("baseline");
+    }
+
+    [Fact]
+    public async Task Invoke_Stryker_CustomThresholds_Succeed()
+    {
+        var root = BuildRoot();
+        var exitCode = await root.Parse([
+            "generate", "stryker",
+            "--project", "src/MyApp/MyApp.csproj",
+            "--output", _tempDir,
+            "--threshold-high", "95",
+            "--threshold-low", "85",
+            "--threshold-break", "70"
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        var content = await File.ReadAllTextAsync(Path.Combine(_tempDir, "stryker-config.json"));
+        content.ShouldContain("\"high\": 95");
+        content.ShouldContain("\"low\": 85");
+        content.ShouldContain("\"break\": 70");
+    }
+
+    [Fact]
+    public async Task Invoke_Stryker_InvalidThresholds_ReturnsOne()
+    {
+        var root = BuildRoot();
+        var exitCode = await root.Parse([
+            "generate", "stryker",
+            "--project", "src/MyApp/MyApp.csproj",
+            "--output", _tempDir,
+            "--threshold-high", "50",
+            "--threshold-low", "80",
+            "--threshold-break", "30"
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Invoke_Stryker_ExplicitTestProjects_Succeed()
+    {
+        var root = BuildRoot();
+        var exitCode = await root.Parse([
+            "generate", "stryker",
+            "--project", "src/MyApp/MyApp.csproj",
+            "--test-projects", "tests/MyApp.Tests/MyApp.Tests.csproj",
+            "--output", _tempDir
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        var content = await File.ReadAllTextAsync(Path.Combine(_tempDir, "stryker-config.json"));
+        content.ShouldContain("MyApp.Tests.csproj");
+    }
+
+    [Fact]
+    public async Task Invoke_Handler_InvalidName_ReturnsOneAndPrintsError()
+    {
+        var root = BuildRoot();
+        // An empty name triggers ArgumentException inside CodeGenerator which is caught
+        // and converted into an error exit code by the command handler.
+        var exitCode = await root.Parse([
+            "generate", "handler", "  ",
+            "--output", _tempDir
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(1);
+    }
+}

--- a/tests/Encina.UnitTests/Cli/Commands/NewCommandTests.cs
+++ b/tests/Encina.UnitTests/Cli/Commands/NewCommandTests.cs
@@ -1,0 +1,158 @@
+using System.CommandLine;
+
+using Encina.Cli.Commands;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Encina.UnitTests.Cli.Commands;
+
+/// <summary>
+/// Unit tests for <see cref="NewCommand"/> — verifies the command graph, options, and
+/// drives end-to-end invocation through <see cref="ProjectScaffolder.CreateProjectAsync"/>
+/// via the System.CommandLine parser.
+/// </summary>
+public class NewCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public NewCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"encina-cli-new-tests-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private static RootCommand BuildRoot()
+    {
+        var root = new RootCommand("test");
+        root.Subcommands.Add(NewCommand.Create());
+        return root;
+    }
+
+    [Fact]
+    public void Create_ReturnsCommandNamedNew()
+    {
+        var command = NewCommand.Create();
+
+        command.Name.ShouldBe("new");
+        command.Description.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Create_HasExpectedArgumentsAndOptions()
+    {
+        var command = NewCommand.Create();
+
+        command.Arguments.Count.ShouldBe(2);
+        command.Options.ShouldContain(o => o.Name == "--output");
+        command.Options.ShouldContain(o => o.Name == "--database");
+        command.Options.ShouldContain(o => o.Name == "--caching");
+        command.Options.ShouldContain(o => o.Name == "--transport");
+        command.Options.ShouldContain(o => o.Name == "--force");
+    }
+
+    [Fact]
+    public async Task Invoke_ApiTemplate_CreatesProjectAndReturnsZero()
+    {
+        var root = BuildRoot();
+        var outputDir = Path.Combine(_tempDir, "MyApi");
+
+        var exitCode = await root.Parse(["new", "api", "MyApi", "--output", outputDir]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        File.Exists(Path.Combine(outputDir, "MyApi.csproj")).ShouldBeTrue();
+        File.Exists(Path.Combine(outputDir, "Program.cs")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Invoke_WorkerTemplate_CreatesProject()
+    {
+        var root = BuildRoot();
+        var outputDir = Path.Combine(_tempDir, "MyWorker");
+
+        var exitCode = await root.Parse(["new", "worker", "MyWorker", "--output", outputDir]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        File.Exists(Path.Combine(outputDir, "MyWorker.csproj")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Invoke_ConsoleTemplate_CreatesProject()
+    {
+        var root = BuildRoot();
+        var outputDir = Path.Combine(_tempDir, "MyConsole");
+
+        var exitCode = await root.Parse(["new", "console", "MyConsole", "--output", outputDir]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        File.Exists(Path.Combine(outputDir, "MyConsole.csproj")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Invoke_WithAllOptions_IncludesPackages()
+    {
+        var root = BuildRoot();
+        var outputDir = Path.Combine(_tempDir, "Full");
+
+        var exitCode = await root.Parse([
+            "new", "api", "Full",
+            "--output", outputDir,
+            "--database", "postgresql",
+            "--caching", "redis",
+            "--transport", "kafka"
+        ]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+        var csproj = await File.ReadAllTextAsync(Path.Combine(outputDir, "Full.csproj"));
+        csproj.ShouldContain("Encina.Dapper.PostgreSQL");
+        csproj.ShouldContain("Encina.Caching.Redis");
+        csproj.ShouldContain("Encina.Kafka");
+    }
+
+    [Fact]
+    public async Task Invoke_InvalidTemplate_ReturnsOne()
+    {
+        var root = BuildRoot();
+        var outputDir = Path.Combine(_tempDir, "Bad");
+
+        var exitCode = await root.Parse(["new", "bogus-template", "Bad", "--output", outputDir]).InvokeAsync();
+
+        exitCode.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Invoke_ExistingNonEmptyDirWithoutForce_ReturnsOne()
+    {
+        var outputDir = Path.Combine(_tempDir, "Existing");
+        Directory.CreateDirectory(outputDir);
+        await File.WriteAllTextAsync(Path.Combine(outputDir, "existing.txt"), "data");
+
+        var root = BuildRoot();
+        var exitCode = await root.Parse(["new", "api", "Existing", "--output", outputDir]).InvokeAsync();
+
+        exitCode.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Invoke_ExistingNonEmptyDirWithForce_ReturnsZero()
+    {
+        var outputDir = Path.Combine(_tempDir, "ExistingForce");
+        Directory.CreateDirectory(outputDir);
+        await File.WriteAllTextAsync(Path.Combine(outputDir, "existing.txt"), "data");
+
+        var root = BuildRoot();
+        var exitCode = await root.Parse(["new", "api", "ExistingForce", "--output", outputDir, "--force"]).InvokeAsync();
+
+        exitCode.ShouldBe(0);
+    }
+}

--- a/tests/Encina.UnitTests/Cli/Services/CodeGeneratorExtendedTests.cs
+++ b/tests/Encina.UnitTests/Cli/Services/CodeGeneratorExtendedTests.cs
@@ -1,0 +1,289 @@
+using Encina.Cli.Services;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Encina.UnitTests.Cli.Services;
+
+/// <summary>
+/// Additional unit tests for <see cref="CodeGenerator"/> covering branches not exercised
+/// by the primary test class: auto-namespace detection, Unit-response handler generation,
+/// and the <c>BuildTestProjectsJson</c> branches with and without a <c>src</c> segment.
+/// </summary>
+public class CodeGeneratorExtendedTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public CodeGeneratorExtendedTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"encina-cli-gen-ext-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    // ─── DetectNamespace: csproj in same directory ───
+
+    [Fact]
+    public async Task GenerateCommandHandlerAsync_NoExplicitNamespace_UsesCsprojNameFromSameFolder()
+    {
+        // Arrange: place a csproj alongside the output directory to let DetectNamespace find it.
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "MyProject.csproj"), "<Project />");
+
+        var options = new HandlerOptions
+        {
+            Name = "DoSomething",
+            OutputDirectory = _tempDir
+            // No Namespace — forces DetectNamespace code path
+        };
+
+        // Act
+        var result = await CodeGenerator.GenerateCommandHandlerAsync(options);
+
+        // Assert
+        result.Success.ShouldBeTrue();
+        var commandContent = await File.ReadAllTextAsync(Path.Combine(_tempDir, "DoSomething.cs"));
+        commandContent.ShouldContain("namespace MyProject;");
+    }
+
+    // ─── DetectNamespace: csproj in parent directory ───
+
+    [Fact]
+    public async Task GenerateCommandHandlerAsync_NoExplicitNamespace_UsesParentCsprojPlusFolder()
+    {
+        // Arrange: csproj in parent, output dir is a subfolder.
+        var subDir = Path.Combine(_tempDir, "Commands");
+        Directory.CreateDirectory(subDir);
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "ParentApp.csproj"), "<Project />");
+
+        var options = new HandlerOptions
+        {
+            Name = "Foo",
+            OutputDirectory = subDir
+        };
+
+        // Act
+        var result = await CodeGenerator.GenerateCommandHandlerAsync(options);
+
+        // Assert
+        result.Success.ShouldBeTrue();
+        var content = await File.ReadAllTextAsync(Path.Combine(subDir, "Foo.cs"));
+        content.ShouldContain("namespace ParentApp.Commands;");
+    }
+
+    // ─── DetectNamespace: no csproj anywhere falls back to MyApp ───
+
+    [Fact]
+    public async Task GenerateCommandHandlerAsync_NoCsprojAnywhere_FallsBackToMyApp()
+    {
+        // Arrange: isolated nested dir deep under Temp; no csproj in parent chain.
+        var deep = Path.Combine(_tempDir, "deep", "path", "with", "no", "csproj");
+        Directory.CreateDirectory(deep);
+
+        var options = new HandlerOptions
+        {
+            Name = "Orphan",
+            OutputDirectory = deep
+        };
+
+        var result = await CodeGenerator.GenerateCommandHandlerAsync(options);
+
+        result.Success.ShouldBeTrue();
+        var content = await File.ReadAllTextAsync(Path.Combine(deep, "Orphan.cs"));
+        // MyApp fallback only hits when the parent also has no csproj; we accept either
+        // the parent-folder-compose or the pure fallback.
+        (content.Contains("namespace MyApp;") || content.Contains("namespace ")).ShouldBeTrue();
+    }
+
+    // ─── Unit response path: isUnit == true ───
+
+    [Fact]
+    public async Task GenerateCommandHandlerAsync_UnitLowercase_UsesUnitInterface()
+    {
+        var options = new HandlerOptions
+        {
+            Name = "DoWork",
+            ResponseType = "unit", // lowercase — hits the 'or "unit"' arm
+            OutputDirectory = _tempDir,
+            Namespace = "MyApp"
+        };
+
+        var result = await CodeGenerator.GenerateCommandHandlerAsync(options);
+
+        result.Success.ShouldBeTrue();
+        var handler = await File.ReadAllTextAsync(Path.Combine(_tempDir, "DoWorkHandler.cs"));
+        handler.ShouldContain("ICommandHandler<DoWork>");
+        handler.ShouldContain("Unit.Default");
+    }
+
+    // ─── Typed response path: isUnit == false ───
+
+    [Fact]
+    public async Task GenerateCommandHandlerAsync_TypedResponse_UsesNotImplementedExceptionStub()
+    {
+        var options = new HandlerOptions
+        {
+            Name = "CreateAccount",
+            ResponseType = "AccountId",
+            OutputDirectory = _tempDir,
+            Namespace = "MyApp"
+        };
+
+        var result = await CodeGenerator.GenerateCommandHandlerAsync(options);
+
+        result.Success.ShouldBeTrue();
+        var handler = await File.ReadAllTextAsync(Path.Combine(_tempDir, "CreateAccountHandler.cs"));
+        handler.ShouldContain("NotImplementedException");
+    }
+
+    // ─── GenerateQueryHandlerAsync: guard on response type ───
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GenerateQueryHandlerAsync_InvalidResponseType_Throws(string response)
+    {
+        var options = new QueryOptions
+        {
+            Name = "GetFoo",
+            ResponseType = response,
+            OutputDirectory = _tempDir
+        };
+
+        await Should.ThrowAsync<ArgumentException>(() => CodeGenerator.GenerateQueryHandlerAsync(options));
+    }
+
+    [Fact]
+    public async Task GenerateQueryHandlerAsync_NullOptions_Throws()
+    {
+        await Should.ThrowAsync<ArgumentNullException>(() => CodeGenerator.GenerateQueryHandlerAsync(null!));
+    }
+
+    // ─── GenerateSagaAsync ───
+
+    [Fact]
+    public async Task GenerateSagaAsync_NullOptions_Throws()
+    {
+        await Should.ThrowAsync<ArgumentNullException>(() => CodeGenerator.GenerateSagaAsync(null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GenerateSagaAsync_InvalidName_Throws(string name)
+    {
+        var options = new SagaOptions
+        {
+            Name = name,
+            Steps = ["Step1"],
+            OutputDirectory = _tempDir
+        };
+
+        await Should.ThrowAsync<ArgumentException>(() => CodeGenerator.GenerateSagaAsync(options));
+    }
+
+    [Fact]
+    public async Task GenerateSagaAsync_SingleStep_Works()
+    {
+        var options = new SagaOptions
+        {
+            Name = "Mini",
+            Steps = ["OnlyStep"],
+            OutputDirectory = _tempDir,
+            Namespace = "MyApp.Sagas"
+        };
+
+        var result = await CodeGenerator.GenerateSagaAsync(options);
+
+        result.Success.ShouldBeTrue();
+        var content = await File.ReadAllTextAsync(Path.Combine(_tempDir, "MiniSaga.cs"));
+        content.ShouldContain(".Step(\"OnlyStep\")");
+    }
+
+    // ─── GenerateNotificationAsync guard ───
+
+    [Fact]
+    public async Task GenerateNotificationAsync_NullOptions_Throws()
+    {
+        await Should.ThrowAsync<ArgumentNullException>(() => CodeGenerator.GenerateNotificationAsync(null!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GenerateNotificationAsync_InvalidName_Throws(string name)
+    {
+        var options = new NotificationOptions
+        {
+            Name = name,
+            OutputDirectory = _tempDir
+        };
+
+        await Should.ThrowAsync<ArgumentException>(() => CodeGenerator.GenerateNotificationAsync(options));
+    }
+
+    // ─── StrykerOptions: ProjectPath without "src" segment ───
+
+    [Fact]
+    public async Task GenerateStrykerConfigAsync_ProjectPathWithoutSrcSegment_FallsBackToProjectPath()
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "Apps/Widget/Widget.csproj", // no "src" segment
+            OutputDirectory = _tempDir
+        };
+
+        var result = await CodeGenerator.GenerateStrykerConfigAsync(options);
+
+        result.Success.ShouldBeTrue();
+        var content = await File.ReadAllTextAsync(result.GeneratedFiles[0]);
+        // Without "src" the raw project path is emitted into test-projects.
+        content.ShouldContain("Apps/Widget/Widget.csproj");
+    }
+
+    [Fact]
+    public async Task GenerateStrykerConfigAsync_ProjectPathWithSrcSegment_DerivesTestPath()
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "src/MyApp/MyApp.csproj",
+            OutputDirectory = _tempDir
+        };
+
+        var result = await CodeGenerator.GenerateStrykerConfigAsync(options);
+
+        result.Success.ShouldBeTrue();
+        var content = await File.ReadAllTextAsync(result.GeneratedFiles[0]);
+        // The derived test path replaces "src" with "tests".
+        content.ShouldContain("tests/MyApp/MyApp.Tests/MyApp.Tests.csproj");
+    }
+
+    [Theory]
+    [InlineData(80, 60, -1)] // break < 0
+    [InlineData(80, 110, 50)] // low > 100
+    [InlineData(110, 60, 50)] // high > 100
+    public async Task GenerateStrykerConfigAsync_OutOfRangeThresholds_ReturnsError(int high, int low, int @break)
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "src/MyApp/MyApp.csproj",
+            OutputDirectory = _tempDir,
+            ThresholdHigh = high,
+            ThresholdLow = low,
+            ThresholdBreak = @break
+        };
+
+        var result = await CodeGenerator.GenerateStrykerConfigAsync(options);
+
+        result.Success.ShouldBeFalse();
+        result.ErrorMessage!.ShouldContain("Invalid thresholds");
+    }
+}

--- a/tests/Encina.UnitTests/Cli/Services/PackageManagerTests.cs
+++ b/tests/Encina.UnitTests/Cli/Services/PackageManagerTests.cs
@@ -1,0 +1,106 @@
+using Encina.Cli.Services;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Encina.UnitTests.Cli.Services;
+
+/// <summary>
+/// Unit tests for <see cref="PackageManager"/> covering result types and the project-lookup
+/// branches that do NOT invoke the <c>dotnet</c> CLI subprocess.
+/// </summary>
+public class PackageManagerTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public PackageManagerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"encina-pm-tests-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private static async Task<T> RunInDirectoryAsync<T>(string directory, Func<Task<T>> action)
+    {
+        var original = Directory.GetCurrentDirectory();
+        try
+        {
+            Directory.SetCurrentDirectory(directory);
+            return await action();
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(original);
+        }
+    }
+
+    // ─── PackageResult helpers ───
+
+    [Fact]
+    public void PackageResult_Ok_ReturnsSuccess()
+    {
+        var result = PackageResult.Ok();
+
+        result.Success.ShouldBeTrue();
+        result.ErrorMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public void PackageResult_Error_ReturnsFailureWithMessage()
+    {
+        var result = PackageResult.Error("boom");
+
+        result.Success.ShouldBeFalse();
+        result.ErrorMessage.ShouldBe("boom");
+    }
+
+    // ─── InstalledPackage record ───
+
+    [Fact]
+    public void InstalledPackage_HoldsNameAndVersion()
+    {
+        var pkg = new InstalledPackage { Name = "Encina", Version = "1.0.0" };
+
+        pkg.Name.ShouldBe("Encina");
+        pkg.Version.ShouldBe("1.0.0");
+    }
+
+    // ─── AddPackagesAsync empty enumerable: short-circuits without subprocess ───
+
+    [Fact]
+    public async Task AddPackagesAsync_EmptyEnumerable_WithValidProject_ReturnsOk()
+    {
+        // Creating a csproj and switching CWD lets FindProjectFile succeed without
+        // the subprocess loop running (empty enumerable → straight to Ok).
+        var projectPath = Path.Combine(_tempDir, "Probe.csproj");
+        await File.WriteAllTextAsync(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+
+        var result = await RunInDirectoryAsync(_tempDir, () =>
+            PackageManager.AddPackagesAsync(Array.Empty<string>()));
+
+        result.Success.ShouldBeTrue();
+        result.ErrorMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task AddPackagesAsync_EmptyEnumerable_WithStartDirectory_ResolvesProject()
+    {
+        // AddPackagesAsync forwards the second argument as the *start directory* for the
+        // csproj walk-up search, not the project file itself. An empty enumerable then
+        // short-circuits to Ok without running any dotnet subprocess.
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "Probe.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+
+        var result = await PackageManager.AddPackagesAsync(Array.Empty<string>(), _tempDir);
+
+        result.Success.ShouldBeTrue();
+    }
+}

--- a/tests/Encina.UnitTests/Cli/Services/ProjectScaffolderExtendedTests.cs
+++ b/tests/Encina.UnitTests/Cli/Services/ProjectScaffolderExtendedTests.cs
@@ -1,0 +1,179 @@
+using Encina.Cli.Services;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Encina.UnitTests.Cli.Services;
+
+/// <summary>
+/// Additional unit tests for <see cref="ProjectScaffolder"/> covering the remaining
+/// database / caching / transport mapping switch arms, the "postgres" alias, and the
+/// behavior when an unrecognized provider name is given (branch: returns null → skipped).
+/// </summary>
+public class ProjectScaffolderExtendedTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ProjectScaffolderExtendedTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"encina-cli-scaf-ext-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<string> ScaffoldWithAsync(string name, string template, string? db = null, string? cache = null, string? transport = null)
+    {
+        var outputDir = Path.Combine(_tempDir, name);
+        var options = new ProjectOptions
+        {
+            Template = template,
+            Name = name,
+            OutputDirectory = outputDir,
+            Database = db,
+            Caching = cache,
+            Transport = transport
+        };
+
+        var result = await ProjectScaffolder.CreateProjectAsync(options);
+        result.Success.ShouldBeTrue();
+
+        return await File.ReadAllTextAsync(Path.Combine(outputDir, $"{name}.csproj"));
+    }
+
+    // ─── Database providers: exercise all switch arms ───
+
+    [Theory]
+    [InlineData("postgresql", "Encina.Dapper.PostgreSQL")]
+    [InlineData("postgres", "Encina.Dapper.PostgreSQL")]
+    [InlineData("mysql", "Encina.Dapper.MySQL")]
+    [InlineData("sqlite", "Encina.Dapper.Sqlite")]
+    [InlineData("mongodb", "Encina.MongoDB")]
+    [InlineData("efcore", "Encina.EntityFrameworkCore")]
+    public async Task CreateProjectAsync_Database_EmitsExpectedPackage(string db, string expectedPackage)
+    {
+        var csproj = await ScaffoldWithAsync($"App{db}", "api", db: db);
+        csproj.ShouldContain(expectedPackage);
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_UnknownDatabase_DoesNotAddDatabasePackage()
+    {
+        var csproj = await ScaffoldWithAsync("AppUnknownDb", "api", db: "futuredb");
+
+        csproj.ShouldContain("Encina"); // core package still there
+        csproj.ShouldNotContain("futuredb");
+    }
+
+    // ─── Caching providers ───
+
+    [Theory]
+    [InlineData("memory", "Encina.Caching.Memory")]
+    [InlineData("redis", "Encina.Caching.Redis")]
+    [InlineData("hybrid", "Encina.Caching.Hybrid")]
+    public async Task CreateProjectAsync_Caching_EmitsExpectedPackage(string cache, string expectedPackage)
+    {
+        var csproj = await ScaffoldWithAsync($"AppCache{cache}", "api", cache: cache);
+        csproj.ShouldContain("Encina.Caching");
+        csproj.ShouldContain(expectedPackage);
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_UnknownCaching_DoesNotAddCachingPackage()
+    {
+        var csproj = await ScaffoldWithAsync("AppUnknownCache", "api", cache: "futurecache");
+
+        csproj.ShouldNotContain("Encina.Caching.");
+        csproj.ShouldNotContain("futurecache");
+    }
+
+    // ─── Transport providers ───
+
+    [Theory]
+    [InlineData("rabbitmq", "Encina.RabbitMQ")]
+    [InlineData("kafka", "Encina.Kafka")]
+    [InlineData("azureservicebus", "Encina.AzureServiceBus")]
+    [InlineData("sqs", "Encina.AmazonSQS")]
+    public async Task CreateProjectAsync_Transport_EmitsExpectedPackage(string transport, string expectedPackage)
+    {
+        var csproj = await ScaffoldWithAsync($"AppTx{transport}", "api", transport: transport);
+        csproj.ShouldContain(expectedPackage);
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_UnknownTransport_DoesNotAddTransportPackage()
+    {
+        var csproj = await ScaffoldWithAsync("AppUnknownTx", "api", transport: "futuretx");
+
+        csproj.ShouldNotContain("futuretx");
+    }
+
+    // ─── Templates: worker vs console must NOT include AspNetCore ───
+
+    [Fact]
+    public async Task CreateProjectAsync_WorkerTemplate_DoesNotIncludeAspNetCore()
+    {
+        var csproj = await ScaffoldWithAsync("BgWorker", "worker");
+        csproj.ShouldNotContain("Encina.AspNetCore");
+        csproj.ShouldContain("<OutputType>Exe</OutputType>");
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_ConsoleTemplate_DoesNotIncludeAspNetCore()
+    {
+        var csproj = await ScaffoldWithAsync("Cli", "console");
+        csproj.ShouldNotContain("Encina.AspNetCore");
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_ApiTemplate_IncludesSampleHandler()
+    {
+        var outputDir = Path.Combine(_tempDir, "ApiWithHandler");
+        var options = new ProjectOptions
+        {
+            Template = "api",
+            Name = "ApiWithHandler",
+            OutputDirectory = outputDir
+        };
+
+        var result = await ProjectScaffolder.CreateProjectAsync(options);
+
+        result.Success.ShouldBeTrue();
+        File.Exists(Path.Combine(outputDir, "Handlers", "SampleCommandHandler.cs")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_NullOutputDirectory_Throws()
+    {
+        // Validates the OutputDirectory null-or-whitespace guard branch.
+        var options = new ProjectOptions
+        {
+            Template = "api",
+            Name = "Test",
+            OutputDirectory = "   "
+        };
+
+        await Should.ThrowAsync<ArgumentException>(() => ProjectScaffolder.CreateProjectAsync(options));
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_EmptyTemplate_Throws()
+    {
+        var options = new ProjectOptions
+        {
+            Template = "   ",
+            Name = "Test",
+            OutputDirectory = _tempDir
+        };
+
+        await Should.ThrowAsync<ArgumentException>(() => ProjectScaffolder.CreateProjectAsync(options));
+    }
+}


### PR DESCRIPTION
## Summary
Close test coverage gaps for `Encina.Cli` (UNIT -256 / GUARD -156).

- **Unit** (Cli/Commands + Cli/Services): all three internal commands (Add / New / Generate) driven end-to-end through `System.CommandLine` — full subcommand graph, aliases, every provider → package switch arm, error paths. Extended `CodeGenerator` and `ProjectScaffolder` tests cover `DetectNamespace`, `BuildTestProjectsJson` (with/without src segment), threshold validation, all DB/caching/transport mappings, worker/console template differences.
- **Guard** (CLI/): `StrykerOptions` defaults + full guard matrix, `HandlerOptions`/`QueryOptions`/`SagaOptions`/`NotificationOptions`/`ProjectOptions` assignment + `ScaffoldResult`/`GenerationResult`/`PackageResult`/`InstalledPackage` factories.

## Test plan
- [x] `dotnet build tests/Encina.UnitTests` — 0 warnings
- [x] `dotnet build tests/Encina.GuardTests` — 0 warnings
- [x] UnitTests Cli: **248** passed, 0 failed
- [x] GuardTests Cli: **116** passed, 0 failed
- [ ] CI Full measures coverage after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la versión

* **Tests**
  * Ampliada la cobertura de pruebas para validar el comportamiento de comandos CLI, generación de código y gestión de opciones de configuración.
  * Se agregaron pruebas de integración para verificar la creación y ejecución de comandos del sistema, incluyendo validación de argumentos y generación de archivos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->