### PR TITLE
test(cli): close remaining -123 GUARD coverage gap

### DIFF
--- a/tests/Encina.GuardTests/CLI/CodeGeneratorHappyPathGuardTests.cs
+++ b/tests/Encina.GuardTests/CLI/CodeGeneratorHappyPathGuardTests.cs
@@ -1,0 +1,396 @@
+using Encina.Cli.Services;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Encina.GuardTests.CLI;
+
+/// <summary>
+/// Guard tests that exercise the happy-path branches of <see cref="CodeGenerator"/> to
+/// produce real line coverage for the guard flag. These complement the pure guard-clause
+/// tests in <see cref="CodeGeneratorGuardTests"/> by running each public method end-to-end
+/// with valid inputs against a disposable temporary directory.
+/// </summary>
+public class CodeGeneratorHappyPathGuardTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public CodeGeneratorHappyPathGuardTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"encina-cli-gcli-hp-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    // ─── Command handler generation ───
+
+    [Fact]
+    public async Task GenerateCommandHandlerAsync_UnitResponse_EmitsCommandAndHandler()
+    {
+        var options = new HandlerOptions
+        {
+            Name = "DoWork",
+            ResponseType = "Unit",
+            OutputDirectory = _tempDir,
+            Namespace = "Sample.Commands"
+        };
+
+        var result = await CodeGenerator.GenerateCommandHandlerAsync(options);
+
+        result.Success.ShouldBeTrue();
+        result.GeneratedFiles.Count.ShouldBe(2);
+        var commandPath = Path.Combine(_tempDir, "DoWork.cs");
+        var handlerPath = Path.Combine(_tempDir, "DoWorkHandler.cs");
+        File.Exists(commandPath).ShouldBeTrue();
+        File.Exists(handlerPath).ShouldBeTrue();
+        (await File.ReadAllTextAsync(commandPath)).ShouldContain("public sealed record DoWork : ICommand");
+        (await File.ReadAllTextAsync(handlerPath)).ShouldContain("ICommandHandler<DoWork>");
+    }
+
+    [Fact]
+    public async Task GenerateCommandHandlerAsync_UnitLowercaseResponse_StillUnit()
+    {
+        var options = new HandlerOptions
+        {
+            Name = "DoLower",
+            ResponseType = "unit",
+            OutputDirectory = _tempDir,
+            Namespace = "Sample"
+        };
+
+        var result = await CodeGenerator.GenerateCommandHandlerAsync(options);
+
+        result.Success.ShouldBeTrue();
+        (await File.ReadAllTextAsync(Path.Combine(_tempDir, "DoLowerHandler.cs"))).ShouldContain("Unit.Default");
+    }
+
+    [Fact]
+    public async Task GenerateCommandHandlerAsync_TypedResponse_UsesResponseType()
+    {
+        var options = new HandlerOptions
+        {
+            Name = "CreateAccount",
+            ResponseType = "AccountId",
+            OutputDirectory = _tempDir,
+            Namespace = "Sample"
+        };
+
+        var result = await CodeGenerator.GenerateCommandHandlerAsync(options);
+
+        result.Success.ShouldBeTrue();
+        (await File.ReadAllTextAsync(Path.Combine(_tempDir, "CreateAccount.cs"))).ShouldContain("ICommand<AccountId>");
+        (await File.ReadAllTextAsync(Path.Combine(_tempDir, "CreateAccountHandler.cs"))).ShouldContain("ICommandHandler<CreateAccount, AccountId>");
+    }
+
+    [Fact]
+    public async Task GenerateCommandHandlerAsync_NoExplicitNamespace_DetectsFromParentCsproj()
+    {
+        // Place a csproj in the parent directory so DetectNamespace walks up and composes.
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "Parent.csproj"), "<Project />");
+        var sub = Path.Combine(_tempDir, "Commands");
+        Directory.CreateDirectory(sub);
+
+        var options = new HandlerOptions
+        {
+            Name = "Foo",
+            OutputDirectory = sub
+        };
+
+        var result = await CodeGenerator.GenerateCommandHandlerAsync(options);
+
+        result.Success.ShouldBeTrue();
+        (await File.ReadAllTextAsync(Path.Combine(sub, "Foo.cs"))).ShouldContain("namespace Parent.Commands;");
+    }
+
+    [Fact]
+    public async Task GenerateCommandHandlerAsync_NoExplicitNamespace_DetectsFromSameFolderCsproj()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "Here.csproj"), "<Project />");
+
+        var options = new HandlerOptions
+        {
+            Name = "Bar",
+            OutputDirectory = _tempDir
+        };
+
+        var result = await CodeGenerator.GenerateCommandHandlerAsync(options);
+
+        result.Success.ShouldBeTrue();
+        (await File.ReadAllTextAsync(Path.Combine(_tempDir, "Bar.cs"))).ShouldContain("namespace Here;");
+    }
+
+    // ─── Query handler generation ───
+
+    [Fact]
+    public async Task GenerateQueryHandlerAsync_ValidOptions_EmitsQueryAndHandler()
+    {
+        var options = new QueryOptions
+        {
+            Name = "GetUserById",
+            ResponseType = "UserDto",
+            OutputDirectory = _tempDir,
+            Namespace = "Sample.Queries"
+        };
+
+        var result = await CodeGenerator.GenerateQueryHandlerAsync(options);
+
+        result.Success.ShouldBeTrue();
+        result.GeneratedFiles.Count.ShouldBe(2);
+        (await File.ReadAllTextAsync(Path.Combine(_tempDir, "GetUserById.cs"))).ShouldContain("IQuery<UserDto>");
+        (await File.ReadAllTextAsync(Path.Combine(_tempDir, "GetUserByIdHandler.cs"))).ShouldContain("IQueryHandler<GetUserById, UserDto>");
+    }
+
+    [Fact]
+    public async Task GenerateQueryHandlerAsync_NoExplicitNamespace_Works()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "Q.csproj"), "<Project />");
+
+        var options = new QueryOptions
+        {
+            Name = "GetSomething",
+            ResponseType = "Something",
+            OutputDirectory = _tempDir
+        };
+
+        var result = await CodeGenerator.GenerateQueryHandlerAsync(options);
+
+        result.Success.ShouldBeTrue();
+    }
+
+    // ─── Saga generation ───
+
+    [Fact]
+    public async Task GenerateSagaAsync_ValidOptions_EmitsDataAndSaga()
+    {
+        var options = new SagaOptions
+        {
+            Name = "OrderFlow",
+            Steps = ["Validate", "Charge", "Ship", "Notify"],
+            OutputDirectory = _tempDir,
+            Namespace = "Sample.Sagas"
+        };
+
+        var result = await CodeGenerator.GenerateSagaAsync(options);
+
+        result.Success.ShouldBeTrue();
+        result.GeneratedFiles.Count.ShouldBe(2);
+        var sagaContent = await File.ReadAllTextAsync(Path.Combine(_tempDir, "OrderFlowSaga.cs"));
+        sagaContent.ShouldContain(".Step(\"Validate\")");
+        sagaContent.ShouldContain(".Step(\"Charge\")");
+        sagaContent.ShouldContain(".Step(\"Ship\")");
+        sagaContent.ShouldContain(".Step(\"Notify\")");
+        (await File.ReadAllTextAsync(Path.Combine(_tempDir, "OrderFlowData.cs"))).ShouldContain("CorrelationId");
+    }
+
+    [Fact]
+    public async Task GenerateSagaAsync_SingleStep_Works()
+    {
+        var options = new SagaOptions
+        {
+            Name = "SingleStep",
+            Steps = ["Only"],
+            OutputDirectory = _tempDir,
+            Namespace = "Sample"
+        };
+
+        var result = await CodeGenerator.GenerateSagaAsync(options);
+
+        result.Success.ShouldBeTrue();
+        (await File.ReadAllTextAsync(Path.Combine(_tempDir, "SingleStepSaga.cs"))).ShouldContain(".Step(\"Only\")");
+    }
+
+    [Fact]
+    public async Task GenerateSagaAsync_NoExplicitNamespace_UsesDetection()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "S.csproj"), "<Project />");
+
+        var options = new SagaOptions
+        {
+            Name = "DetectNs",
+            Steps = ["A"],
+            OutputDirectory = _tempDir
+        };
+
+        var result = await CodeGenerator.GenerateSagaAsync(options);
+
+        result.Success.ShouldBeTrue();
+    }
+
+    // ─── Notification generation ───
+
+    [Fact]
+    public async Task GenerateNotificationAsync_ValidOptions_EmitsFiles()
+    {
+        var options = new NotificationOptions
+        {
+            Name = "OrderPlaced",
+            OutputDirectory = _tempDir,
+            Namespace = "Sample.Events"
+        };
+
+        var result = await CodeGenerator.GenerateNotificationAsync(options);
+
+        result.Success.ShouldBeTrue();
+        result.GeneratedFiles.Count.ShouldBe(2);
+        (await File.ReadAllTextAsync(Path.Combine(_tempDir, "OrderPlaced.cs"))).ShouldContain("INotification");
+        (await File.ReadAllTextAsync(Path.Combine(_tempDir, "OrderPlacedHandler.cs"))).ShouldContain("INotificationHandler<OrderPlaced>");
+    }
+
+    [Fact]
+    public async Task GenerateNotificationAsync_NoExplicitNamespace_Works()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "N.csproj"), "<Project />");
+
+        var options = new NotificationOptions
+        {
+            Name = "Notified",
+            OutputDirectory = _tempDir
+        };
+
+        var result = await CodeGenerator.GenerateNotificationAsync(options);
+
+        result.Success.ShouldBeTrue();
+    }
+
+    // ─── Stryker config generation ───
+
+    [Fact]
+    public async Task GenerateStrykerConfigAsync_BasicConfig_Succeeds()
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "src/MyApp/MyApp.csproj",
+            OutputDirectory = _tempDir
+        };
+
+        var result = await CodeGenerator.GenerateStrykerConfigAsync(options);
+
+        result.Success.ShouldBeTrue();
+        var content = await File.ReadAllTextAsync(Path.Combine(_tempDir, "stryker-config.json"));
+        content.ShouldContain("\"high\": 80");
+        content.ShouldContain("\"low\": 60");
+        content.ShouldContain("\"break\": 50");
+        content.ShouldNotContain("baseline");
+    }
+
+    [Fact]
+    public async Task GenerateStrykerConfigAsync_AdvancedConfig_IncludesBaselineAndSince()
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "src/MyApp/MyApp.csproj",
+            OutputDirectory = _tempDir,
+            UseAdvanced = true
+        };
+
+        var result = await CodeGenerator.GenerateStrykerConfigAsync(options);
+
+        result.Success.ShouldBeTrue();
+        var content = await File.ReadAllTextAsync(Path.Combine(_tempDir, "stryker-config.json"));
+        content.ShouldContain("baseline");
+        content.ShouldContain("\"since\"");
+        content.ShouldContain("ignore-methods");
+    }
+
+    [Fact]
+    public async Task GenerateStrykerConfigAsync_CustomThresholds_Work()
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "src/MyApp/MyApp.csproj",
+            OutputDirectory = _tempDir,
+            ThresholdHigh = 95,
+            ThresholdLow = 75,
+            ThresholdBreak = 60
+        };
+
+        var result = await CodeGenerator.GenerateStrykerConfigAsync(options);
+
+        result.Success.ShouldBeTrue();
+        var content = await File.ReadAllTextAsync(Path.Combine(_tempDir, "stryker-config.json"));
+        content.ShouldContain("\"high\": 95");
+        content.ShouldContain("\"low\": 75");
+        content.ShouldContain("\"break\": 60");
+    }
+
+    [Fact]
+    public async Task GenerateStrykerConfigAsync_ExplicitTestProjects_EmittedInConfig()
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "src/MyApp/MyApp.csproj",
+            TestProjects = ["tests/MyApp.Tests/MyApp.Tests.csproj", "tests/MyApp.Other/MyApp.Other.csproj"],
+            OutputDirectory = _tempDir
+        };
+
+        var result = await CodeGenerator.GenerateStrykerConfigAsync(options);
+
+        result.Success.ShouldBeTrue();
+        var content = await File.ReadAllTextAsync(Path.Combine(_tempDir, "stryker-config.json"));
+        content.ShouldContain("MyApp.Tests.csproj");
+        content.ShouldContain("MyApp.Other.csproj");
+    }
+
+    [Fact]
+    public async Task GenerateStrykerConfigAsync_ProjectPathWithSrcSegment_DerivesTestPath()
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "src/MyApp/MyApp.csproj",
+            OutputDirectory = _tempDir
+        };
+
+        var result = await CodeGenerator.GenerateStrykerConfigAsync(options);
+
+        result.Success.ShouldBeTrue();
+        var content = await File.ReadAllTextAsync(Path.Combine(_tempDir, "stryker-config.json"));
+        content.ShouldContain("tests/MyApp/MyApp.Tests/MyApp.Tests.csproj");
+    }
+
+    [Fact]
+    public async Task GenerateStrykerConfigAsync_ProjectPathWithoutSrcSegment_FallsBack()
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "Apps/Widget/Widget.csproj",
+            OutputDirectory = _tempDir
+        };
+
+        var result = await CodeGenerator.GenerateStrykerConfigAsync(options);
+
+        result.Success.ShouldBeTrue();
+        var content = await File.ReadAllTextAsync(Path.Combine(_tempDir, "stryker-config.json"));
+        content.ShouldContain("Apps/Widget/Widget.csproj");
+    }
+
+    [Theory]
+    [InlineData(80, 60, 70)] // break > low
+    [InlineData(60, 80, 50)] // low > high
+    [InlineData(80, 60, -1)] // break < 0
+    [InlineData(101, 60, 50)] // high > 100
+    public async Task GenerateStrykerConfigAsync_InvalidThresholds_ReturnError(int high, int low, int @break)
+    {
+        var options = new StrykerOptions
+        {
+            ProjectPath = "src/X/X.csproj",
+            OutputDirectory = _tempDir,
+            ThresholdHigh = high,
+            ThresholdLow = low,
+            ThresholdBreak = @break
+        };
+
+        var result = await CodeGenerator.GenerateStrykerConfigAsync(options);
+
+        result.Success.ShouldBeFalse();
+        result.ErrorMessage!.ShouldContain("Invalid thresholds");
+    }
+}

--- a/tests/Encina.GuardTests/CLI/PackageManagerHappyPathGuardTests.cs
+++ b/tests/Encina.GuardTests/CLI/PackageManagerHappyPathGuardTests.cs
@@ -1,0 +1,84 @@
+using Encina.Cli.Services;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Encina.GuardTests.CLI;
+
+/// <summary>
+/// Guard tests exercising non-subprocess code paths in <see cref="PackageManager"/> to
+/// produce line coverage for the guard flag. Subprocess-invoking paths (Add/Remove/List
+/// via <c>dotnet</c>) are deliberately avoided because they would slow the guard pass.
+/// </summary>
+public class PackageManagerHappyPathGuardTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public PackageManagerHappyPathGuardTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"encina-cli-pm-hp-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task AddPackagesAsync_EmptyEnumerable_WithStartDirectory_FindsProjectAndShortCircuits()
+    {
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "Probe.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+
+        var result = await PackageManager.AddPackagesAsync(Array.Empty<string>(), _tempDir);
+
+        result.Success.ShouldBeTrue();
+        result.ErrorMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task AddPackagesAsync_EmptyEnumerable_NoProjectFoundInChain_ReturnsError()
+    {
+        // Nested directory deep enough to be isolated from any ambient csproj in Temp.
+        // If the walk-up happens to find one (dev scenarios), we accept either outcome.
+        var deep = Path.Combine(_tempDir, "a", "b", "c", "d");
+        Directory.CreateDirectory(deep);
+
+        var result = await PackageManager.AddPackagesAsync(Array.Empty<string>(), deep);
+
+        // Either branch executes the FindProjectFile walk-up path.
+        (result.Success || !string.IsNullOrEmpty(result.ErrorMessage)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void PackageResult_Ok_HasNoErrorMessage()
+    {
+        var result = PackageResult.Ok();
+
+        result.Success.ShouldBeTrue();
+        result.ErrorMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public void PackageResult_Error_HasErrorMessage()
+    {
+        var result = PackageResult.Error("failure");
+
+        result.Success.ShouldBeFalse();
+        result.ErrorMessage.ShouldBe("failure");
+    }
+
+    [Fact]
+    public void InstalledPackage_AssignsNameAndVersion()
+    {
+        var pkg = new InstalledPackage { Name = "Encina", Version = "1.2.3" };
+
+        pkg.Name.ShouldBe("Encina");
+        pkg.Version.ShouldBe("1.2.3");
+    }
+}

--- a/tests/Encina.GuardTests/CLI/ProjectScaffolderHappyPathGuardTests.cs
+++ b/tests/Encina.GuardTests/CLI/ProjectScaffolderHappyPathGuardTests.cs
@@ -1,0 +1,246 @@
+using Encina.Cli.Services;
+
+using Shouldly;
+
+using Xunit;
+
+namespace Encina.GuardTests.CLI;
+
+/// <summary>
+/// Guard tests that exercise happy-path branches of <see cref="ProjectScaffolder"/> to
+/// generate real line coverage for the guard flag.
+/// </summary>
+public class ProjectScaffolderHappyPathGuardTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ProjectScaffolderHappyPathGuardTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"encina-cli-ps-hp-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<string> ScaffoldAsync(string name, string template, string? db = null, string? cache = null, string? transport = null, bool force = false)
+    {
+        var outputDir = Path.Combine(_tempDir, name);
+        var options = new ProjectOptions
+        {
+            Template = template,
+            Name = name,
+            OutputDirectory = outputDir,
+            Database = db,
+            Caching = cache,
+            Transport = transport,
+            Force = force
+        };
+
+        var result = await ProjectScaffolder.CreateProjectAsync(options);
+        result.Success.ShouldBeTrue();
+        return await File.ReadAllTextAsync(Path.Combine(outputDir, $"{name}.csproj"));
+    }
+
+    // ─── Templates ───
+
+    [Fact]
+    public async Task CreateProjectAsync_ApiTemplate_EmitsAspNetCoreAndHandler()
+    {
+        var outputDir = Path.Combine(_tempDir, "ApiApp");
+        var result = await ProjectScaffolder.CreateProjectAsync(new ProjectOptions
+        {
+            Template = "api",
+            Name = "ApiApp",
+            OutputDirectory = outputDir
+        });
+
+        result.Success.ShouldBeTrue();
+        File.Exists(Path.Combine(outputDir, "ApiApp.csproj")).ShouldBeTrue();
+        File.Exists(Path.Combine(outputDir, "Program.cs")).ShouldBeTrue();
+        File.Exists(Path.Combine(outputDir, "Handlers", "SampleCommandHandler.cs")).ShouldBeTrue();
+
+        var csproj = await File.ReadAllTextAsync(Path.Combine(outputDir, "ApiApp.csproj"));
+        csproj.ShouldContain("Encina.AspNetCore");
+        csproj.ShouldContain("net10.0");
+
+        var programContent = await File.ReadAllTextAsync(Path.Combine(outputDir, "Program.cs"));
+        programContent.ShouldContain("WebApplication.CreateBuilder");
+        programContent.ShouldContain("AddEncinaAspNetCore");
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_WorkerTemplate_EmitsExeOutput()
+    {
+        var csproj = await ScaffoldAsync("WorkerApp", "worker");
+
+        csproj.ShouldContain("<OutputType>Exe</OutputType>");
+        csproj.ShouldNotContain("Encina.AspNetCore");
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_ConsoleTemplate_EmitsServiceCollection()
+    {
+        var outputDir = Path.Combine(_tempDir, "ConsoleApp");
+        await ProjectScaffolder.CreateProjectAsync(new ProjectOptions
+        {
+            Template = "console",
+            Name = "ConsoleApp",
+            OutputDirectory = outputDir
+        });
+
+        var program = await File.ReadAllTextAsync(Path.Combine(outputDir, "Program.cs"));
+        program.ShouldContain("ServiceCollection");
+        program.ShouldContain("BuildServiceProvider");
+    }
+
+    // ─── Database providers ───
+
+    [Theory]
+    [InlineData("sqlserver", "Encina.Dapper.SqlServer")]
+    [InlineData("postgresql", "Encina.Dapper.PostgreSQL")]
+    [InlineData("postgres", "Encina.Dapper.PostgreSQL")]
+    [InlineData("mysql", "Encina.Dapper.MySQL")]
+    [InlineData("sqlite", "Encina.Dapper.Sqlite")]
+    [InlineData("mongodb", "Encina.MongoDB")]
+    [InlineData("efcore", "Encina.EntityFrameworkCore")]
+    public async Task CreateProjectAsync_Database_EmitsExpectedPackage(string db, string expected)
+    {
+        var csproj = await ScaffoldAsync($"DbApp{db}", "api", db: db);
+        csproj.ShouldContain(expected);
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_UnknownDatabase_DoesNotAddPackage()
+    {
+        var csproj = await ScaffoldAsync("UnknownDb", "api", db: "neverheard");
+        csproj.ShouldNotContain("neverheard");
+    }
+
+    // ─── Caching providers ───
+
+    [Theory]
+    [InlineData("memory", "Encina.Caching.Memory")]
+    [InlineData("redis", "Encina.Caching.Redis")]
+    [InlineData("hybrid", "Encina.Caching.Hybrid")]
+    public async Task CreateProjectAsync_Caching_EmitsExpectedPackage(string cache, string expected)
+    {
+        var csproj = await ScaffoldAsync($"CacheApp{cache}", "api", cache: cache);
+        csproj.ShouldContain("Encina.Caching");
+        csproj.ShouldContain(expected);
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_UnknownCaching_DoesNotAddPackage()
+    {
+        var csproj = await ScaffoldAsync("UnknownCache", "api", cache: "nocache");
+        csproj.ShouldNotContain("Encina.Caching.");
+    }
+
+    // ─── Transport providers ───
+
+    [Theory]
+    [InlineData("rabbitmq", "Encina.RabbitMQ")]
+    [InlineData("kafka", "Encina.Kafka")]
+    [InlineData("azureservicebus", "Encina.AzureServiceBus")]
+    [InlineData("sqs", "Encina.AmazonSQS")]
+    public async Task CreateProjectAsync_Transport_EmitsExpectedPackage(string transport, string expected)
+    {
+        var csproj = await ScaffoldAsync($"TxApp{transport}", "api", transport: transport);
+        csproj.ShouldContain(expected);
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_UnknownTransport_DoesNotAddPackage()
+    {
+        var csproj = await ScaffoldAsync("UnknownTx", "api", transport: "notx");
+        csproj.ShouldNotContain("notx");
+    }
+
+    // ─── Directory + force behavior ───
+
+    [Fact]
+    public async Task CreateProjectAsync_NonEmptyDir_WithoutForce_ReturnsError()
+    {
+        var outputDir = Path.Combine(_tempDir, "NonEmpty");
+        Directory.CreateDirectory(outputDir);
+        await File.WriteAllTextAsync(Path.Combine(outputDir, "marker.txt"), "x");
+
+        var result = await ProjectScaffolder.CreateProjectAsync(new ProjectOptions
+        {
+            Template = "api",
+            Name = "NonEmpty",
+            OutputDirectory = outputDir
+        });
+
+        result.Success.ShouldBeFalse();
+        result.ErrorMessage!.ShouldContain("not empty");
+        result.ErrorMessage!.ShouldContain("--force");
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_NonEmptyDir_WithForce_Succeeds()
+    {
+        var outputDir = Path.Combine(_tempDir, "Forced");
+        Directory.CreateDirectory(outputDir);
+        await File.WriteAllTextAsync(Path.Combine(outputDir, "marker.txt"), "x");
+
+        var result = await ProjectScaffolder.CreateProjectAsync(new ProjectOptions
+        {
+            Template = "api",
+            Name = "Forced",
+            OutputDirectory = outputDir,
+            Force = true
+        });
+
+        result.Success.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_EmptyExistingDir_Succeeds()
+    {
+        var outputDir = Path.Combine(_tempDir, "EmptyExisting");
+        Directory.CreateDirectory(outputDir);
+
+        var result = await ProjectScaffolder.CreateProjectAsync(new ProjectOptions
+        {
+            Template = "console",
+            Name = "EmptyExisting",
+            OutputDirectory = outputDir
+        });
+
+        result.Success.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task CreateProjectAsync_InvalidTemplate_ReturnsError()
+    {
+        var result = await ProjectScaffolder.CreateProjectAsync(new ProjectOptions
+        {
+            Template = "bogus",
+            Name = "Bad",
+            OutputDirectory = Path.Combine(_tempDir, "Bad")
+        });
+
+        result.Success.ShouldBeFalse();
+        result.ErrorMessage!.ShouldContain("Unknown template");
+    }
+
+    // ─── Combined options on all templates ───
+
+    [Fact]
+    public async Task CreateProjectAsync_AllOptionsCombined_EmitsAllPackages()
+    {
+        var csproj = await ScaffoldAsync("FullApp", "api", db: "postgresql", cache: "redis", transport: "kafka");
+        csproj.ShouldContain("Encina.Dapper.PostgreSQL");
+        csproj.ShouldContain("Encina.Caching.Redis");
+        csproj.ShouldContain("Encina.Kafka");
+        csproj.ShouldContain("Encina.AspNetCore");
+    }
+}


### PR DESCRIPTION
## Summary
Close the last ~123 lines missing from the guard flag for `Encina.Cli`.

Previous guard tests covered only null-guard clauses and POCO assignment. This PR adds **happy-path guard tests** that exercise the real method bodies of the services end-to-end.

New test files (CLI/):
- **CodeGeneratorHappyPathGuardTests** (21 tests) — Generate{CommandHandler,QueryHandler,Saga,Notification,StrykerConfig}Async full branches
- **ProjectScaffolderHappyPathGuardTests** (24 tests) — every DB/cache/transport switch arm + templates + force/directory logic
- **PackageManagerHappyPathGuardTests** (6 tests) — AddPackagesAsync empty-enumerable short-circuit + POCO factories

## Test plan
- [x] `dotnet build tests/Encina.GuardTests` — 0 warnings
- [x] GuardTests Cli: **168** passed (was 116), 0 failed
- [ ] CI Full measures final coverage after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Se amplió la cobertura de pruebas para generación de código con validación de controladores de comandos, controladores de consultas, sagas, generación de notificaciones y escenarios de configuración de Stryker
* Se añadieron pruebas de gestión de paquetes asegurando el manejo adecuado de listas vacías, condiciones de error y validación de resultados
* Se añadieron pruebas de scaffolding de proyectos cubriendo plantillas de API, worker y consola con validación exhaustiva de proveedores de base de datos, caché y transporte

<!-- end of auto-generated comment: release notes by coderabbit.ai -->