### PR TITLE
fix(audit-marten): use IDocumentOperations in projections

### DIFF
--- a/src/Encina.Audit.Marten/Projections/AuditEntryProjection.cs
+++ b/src/Encina.Audit.Marten/Projections/AuditEntryProjection.cs
@@ -118,37 +118,41 @@ public sealed class AuditEntryProjection : EventProjection
 
     /// <summary>
     /// Loads the active temporal key material for a given period via Marten's
-    /// <see cref="IQuerySession"/>, honoring the destroyed marker for crypto-shredded periods.
+    /// <see cref="IQuerySession"/>.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// Optimized to a single database round-trip: the latest active key is fetched directly
+    /// via <c>OrderByDescending(Version).FirstOrDefaultAsync</c>, pushing the ordering and
+    /// limit down to PostgreSQL instead of materializing all versions into memory. This keeps
+    /// the hot path of the async projection daemon as cheap as possible (one query per event).
+    /// </para>
+    /// <para>
+    /// For projection purposes, a missing active key is equivalent to crypto-shredding:
+    /// the PII fields become unrecoverable either way, so the projection substitutes the
+    /// configured placeholder. The <see cref="TemporalKeyDestroyedMarker"/> document is
+    /// therefore <b>not</b> consulted here — it only exists to serve the
+    /// <c>MartenTemporalKeyProvider</c> public API, which needs to distinguish
+    /// destroyed-vs-never-existed for its callers.
+    /// </para>
+    /// <para>
     /// This is exposed as <c>internal</c> so unit tests can verify the key-lookup contract
     /// against an in-memory Marten session or a stub without invoking the full projection pipeline.
+    /// </para>
     /// </remarks>
     internal static async Task<(byte[]? KeyMaterial, bool IsShredded)> LoadTemporalKeyAsync(
         IQuerySession session,
         string period,
         CancellationToken cancellationToken)
     {
-        var destroyedDoc = await session.LoadAsync<TemporalKeyDestroyedMarker>(
-            TemporalPeriodHelper.FormatDestroyedMarkerId(period),
-            cancellationToken).ConfigureAwait(false);
-
-        if (destroyedDoc is not null)
-        {
-            return (null, true);
-        }
-
-        var activeKeys = await session.Query<TemporalKeyDocument>()
+        var activeKey = await session.Query<TemporalKeyDocument>()
             .Where(d => d.Period == period && d.Status == TemporalKeyStatus.Active)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
+            .OrderByDescending(d => d.Version)
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 
-        if (activeKeys.Count == 0)
-        {
-            return (null, true);
-        }
-
-        var activeKey = activeKeys.OrderByDescending(k => k.Version).First();
-        return (activeKey.KeyMaterial, false);
+        return activeKey is not null
+            ? (activeKey.KeyMaterial, false)
+            : (null, true);
     }
 
     /// <summary>

--- a/src/Encina.Audit.Marten/Projections/AuditEntryProjection.cs
+++ b/src/Encina.Audit.Marten/Projections/AuditEntryProjection.cs
@@ -110,14 +110,6 @@ public sealed class AuditEntryProjection : EventProjection
         var (keyMaterial, isShredded) = await LoadTemporalKeyAsync(
             operations, @event.TemporalKeyPeriod, cancellationToken).ConfigureAwait(false);
 
-        if (isShredded)
-        {
-            _logger.LogDebug(
-                "Temporal key for period {Period} not found — marking audit entry {EntryId} as shredded",
-                @event.TemporalKeyPeriod,
-                @event.Id);
-        }
-
         return MapToReadModel(@event, keyMaterial, isShredded);
     }
 
@@ -126,6 +118,13 @@ public sealed class AuditEntryProjection : EventProjection
     /// <see cref="IQuerySession"/>.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// This is a thin I/O wrapper: it issues the two Marten queries (active key, destroyed
+    /// marker) and delegates the actual decision to <see cref="ClassifyTemporalKeyLookup"/>,
+    /// which is pure and fully unit-tested. The Marten LINQ pipeline
+    /// (<c>IMartenQueryable.FirstOrDefaultAsync</c>) cannot be reliably faked at the unit-test
+    /// level, so this wrapper itself is exercised end-to-end by integration tests (see #951).
+    /// </para>
     /// <para>
     /// Lookup strategy, ordered for the common case:
     /// </para>
@@ -149,10 +148,6 @@ public sealed class AuditEntryProjection : EventProjection
     /// the read model. Throwing causes Marten to retry the projection on the next pass.
     /// </item>
     /// </list>
-    /// <para>
-    /// This is exposed as <c>internal</c> so unit tests can verify the lookup contract against
-    /// an in-memory Marten session or a stub without invoking the full projection pipeline.
-    /// </para>
     /// </remarks>
     /// <exception cref="KeyNotFoundException">
     /// Thrown when neither an active key nor a destroyed marker exists for the given period,
@@ -169,24 +164,62 @@ public sealed class AuditEntryProjection : EventProjection
             .OrderByDescending(d => d.Version)
             .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 
+        // Only fetch the destroyed marker if the active-key lookup came up empty,
+        // keeping the hot path to a single indexed query.
+        TemporalKeyDestroyedMarker? destroyedDoc = null;
+        if (activeKey is null)
+        {
+            destroyedDoc = await session.LoadAsync<TemporalKeyDestroyedMarker>(
+                TemporalPeriodHelper.FormatDestroyedMarkerId(period),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return ClassifyTemporalKeyLookup(activeKey, destroyedDoc, period);
+    }
+
+    /// <summary>
+    /// Pure classification logic that maps an (activeKey, destroyedMarker) lookup result
+    /// into the tuple consumed by <see cref="MapToReadModel"/>.
+    /// </summary>
+    /// <param name="activeKey">
+    /// The latest active temporal key for the period, or <c>null</c> if none exists.
+    /// </param>
+    /// <param name="destroyedMarker">
+    /// The destruction marker for the period, or <c>null</c> if the period has not been
+    /// crypto-shredded. Only consulted when <paramref name="activeKey"/> is <c>null</c>.
+    /// </param>
+    /// <param name="period">The temporal period identifier (used in the error message).</param>
+    /// <returns>
+    /// A tuple where:
+    /// <list type="bullet">
+    /// <item><c>(keyMaterial, false)</c> — an active key was found</item>
+    /// <item><c>(null, true)</c> — no active key, destroyed marker present (crypto-shredded)</item>
+    /// </list>
+    /// </returns>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown when both <paramref name="activeKey"/> and <paramref name="destroyedMarker"/>
+    /// are <c>null</c>. This indicates transient inconsistency — see
+    /// <see cref="LoadTemporalKeyAsync"/> for the full rationale.
+    /// </exception>
+    /// <remarks>
+    /// This function is extracted and exposed as <c>internal</c> so the three decision paths
+    /// can be unit-tested exhaustively without needing to mock Marten's LINQ pipeline.
+    /// </remarks>
+    internal static (byte[]? KeyMaterial, bool IsShredded) ClassifyTemporalKeyLookup(
+        TemporalKeyDocument? activeKey,
+        TemporalKeyDestroyedMarker? destroyedMarker,
+        string period)
+    {
         if (activeKey is not null)
         {
             return (activeKey.KeyMaterial, false);
         }
 
-        // Rare case: no active key. Check for an explicit destruction marker to distinguish
-        // crypto-shredded periods (permanent) from transient inconsistency (retryable).
-        var destroyedDoc = await session.LoadAsync<TemporalKeyDestroyedMarker>(
-            TemporalPeriodHelper.FormatDestroyedMarkerId(period),
-            cancellationToken).ConfigureAwait(false);
-
-        if (destroyedDoc is not null)
+        if (destroyedMarker is not null)
         {
             return (null, true);
         }
 
-        // Neither active key nor destroyed marker — transient. Throw so the async daemon retries
-        // instead of advancing the high-water mark over an incorrectly-shredded read model.
         throw new KeyNotFoundException(
             $"Temporal key for period '{period}' not found: no active key and no destroyed marker. " +
             "This indicates transient inconsistency (replication lag, pending write, or similar). " +
@@ -207,6 +240,14 @@ public sealed class AuditEntryProjection : EventProjection
         byte[]? keyMaterial,
         bool isShredded)
     {
+        if (isShredded)
+        {
+            _logger.LogDebug(
+                "Temporal key for period {Period} not found — marking audit entry {EntryId} as shredded",
+                @event.TemporalKeyPeriod,
+                @event.Id);
+        }
+
         var placeholder = _shreddedPlaceholder;
 
         return new AuditEntryReadModel

--- a/src/Encina.Audit.Marten/Projections/AuditEntryProjection.cs
+++ b/src/Encina.Audit.Marten/Projections/AuditEntryProjection.cs
@@ -64,12 +64,17 @@ public sealed class AuditEntryProjection : EventProjection
     /// The placeholder substituted for PII fields when the temporal key has been destroyed.
     /// </param>
     /// <param name="logger">Logger used for projection diagnostics.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="shreddedPlaceholder"/> is <c>null</c>, empty, or whitespace.
+    /// An empty or whitespace placeholder would project PII fields as blank strings instead
+    /// of masking them, which defeats the purpose of crypto-shredding.
+    /// </exception>
     /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="shreddedPlaceholder"/> or <paramref name="logger"/> is <c>null</c>.
+    /// Thrown when <paramref name="logger"/> is <c>null</c>.
     /// </exception>
     public AuditEntryProjection(string shreddedPlaceholder, ILogger<AuditEntryProjection> logger)
     {
-        ArgumentNullException.ThrowIfNull(shreddedPlaceholder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(shreddedPlaceholder);
         ArgumentNullException.ThrowIfNull(logger);
 
         Name = "AuditEntryProjection";
@@ -122,37 +127,70 @@ public sealed class AuditEntryProjection : EventProjection
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Optimized to a single database round-trip: the latest active key is fetched directly
-    /// via <c>OrderByDescending(Version).FirstOrDefaultAsync</c>, pushing the ordering and
-    /// limit down to PostgreSQL instead of materializing all versions into memory. This keeps
-    /// the hot path of the async projection daemon as cheap as possible (one query per event).
+    /// Lookup strategy, ordered for the common case:
     /// </para>
+    /// <list type="number">
+    /// <item>
+    /// Fetch the latest active key in a single query via
+    /// <c>OrderByDescending(Version).FirstOrDefaultAsync</c>, pushing ordering and limit down
+    /// to PostgreSQL. Common case: one query per event, no in-memory sorting.
+    /// </item>
+    /// <item>
+    /// If no active key is found, check for an explicit
+    /// <see cref="TemporalKeyDestroyedMarker"/>. If present, the period was crypto-shredded
+    /// and the projection substitutes the placeholder (<c>IsShredded = true</c>).
+    /// </item>
+    /// <item>
+    /// If neither an active key nor a destroyed marker exists, the lookup throws
+    /// <see cref="KeyNotFoundException"/>. This is <b>deliberately retryable</b>: the absence
+    /// of both documents can be caused by replication lag, a transient read-your-writes delay,
+    /// or a pending write on the primary. Persisting <c>IsShredded = true</c> in that scenario
+    /// would advance the async projection daemon's high-water mark and permanently corrupt
+    /// the read model. Throwing causes Marten to retry the projection on the next pass.
+    /// </item>
+    /// </list>
     /// <para>
-    /// For projection purposes, a missing active key is equivalent to crypto-shredding:
-    /// the PII fields become unrecoverable either way, so the projection substitutes the
-    /// configured placeholder. The <see cref="TemporalKeyDestroyedMarker"/> document is
-    /// therefore <b>not</b> consulted here — it only exists to serve the
-    /// <c>MartenTemporalKeyProvider</c> public API, which needs to distinguish
-    /// destroyed-vs-never-existed for its callers.
-    /// </para>
-    /// <para>
-    /// This is exposed as <c>internal</c> so unit tests can verify the key-lookup contract
-    /// against an in-memory Marten session or a stub without invoking the full projection pipeline.
+    /// This is exposed as <c>internal</c> so unit tests can verify the lookup contract against
+    /// an in-memory Marten session or a stub without invoking the full projection pipeline.
     /// </para>
     /// </remarks>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown when neither an active key nor a destroyed marker exists for the given period,
+    /// indicating transient inconsistency. The Marten async projection daemon will retry.
+    /// </exception>
     internal static async Task<(byte[]? KeyMaterial, bool IsShredded)> LoadTemporalKeyAsync(
         IQuerySession session,
         string period,
         CancellationToken cancellationToken)
     {
+        // Common case: fetch the latest active key in a single query.
         var activeKey = await session.Query<TemporalKeyDocument>()
             .Where(d => d.Period == period && d.Status == TemporalKeyStatus.Active)
             .OrderByDescending(d => d.Version)
             .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 
-        return activeKey is not null
-            ? (activeKey.KeyMaterial, false)
-            : (null, true);
+        if (activeKey is not null)
+        {
+            return (activeKey.KeyMaterial, false);
+        }
+
+        // Rare case: no active key. Check for an explicit destruction marker to distinguish
+        // crypto-shredded periods (permanent) from transient inconsistency (retryable).
+        var destroyedDoc = await session.LoadAsync<TemporalKeyDestroyedMarker>(
+            TemporalPeriodHelper.FormatDestroyedMarkerId(period),
+            cancellationToken).ConfigureAwait(false);
+
+        if (destroyedDoc is not null)
+        {
+            return (null, true);
+        }
+
+        // Neither active key nor destroyed marker — transient. Throw so the async daemon retries
+        // instead of advancing the high-water mark over an incorrectly-shredded read model.
+        throw new KeyNotFoundException(
+            $"Temporal key for period '{period}' not found: no active key and no destroyed marker. " +
+            "This indicates transient inconsistency (replication lag, pending write, or similar). " +
+            "The Marten async projection daemon will retry on the next pass.");
     }
 
     /// <summary>

--- a/src/Encina.Audit.Marten/Projections/AuditEntryProjection.cs
+++ b/src/Encina.Audit.Marten/Projections/AuditEntryProjection.cs
@@ -4,11 +4,11 @@ using Encina.Audit.Marten.Crypto;
 using Encina.Audit.Marten.Events;
 using Encina.Security.Audit;
 
+using Marten;
 using Marten.Events.Projections;
 
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Encina.Audit.Marten.Projections;
 
@@ -26,95 +26,176 @@ namespace Encina.Audit.Marten.Projections;
 /// During processing, the projection:
 /// <list type="number">
 /// <item>Receives <see cref="AuditEntryRecordedEvent"/> from the event stream</item>
-/// <item>Resolves <see cref="ITemporalKeyProvider"/> from DI to retrieve decryption keys</item>
-/// <item>Decrypts PII fields using the temporal key for the entry's period</item>
-/// <item>If the key has been destroyed (crypto-shredded), substitutes <c>[SHREDDED]</c>
-/// and sets <see cref="AuditEntryReadModel.IsShredded"/> to <c>true</c></item>
+/// <item>Uses the projection-scoped <see cref="IDocumentOperations"/> to load the
+/// <see cref="TemporalKeyDocument"/> for the entry's period</item>
+/// <item>Decrypts PII fields using the temporal key material</item>
+/// <item>If the key has been destroyed (crypto-shredded), substitutes the configured
+/// shredded placeholder and sets <see cref="AuditEntryReadModel.IsShredded"/> to <c>true</c></item>
 /// <item>Stores the resulting <see cref="AuditEntryReadModel"/> as a Marten document</item>
 /// </list>
+/// </para>
+/// <para>
+/// <b>Note:</b> Marten's projection validation only supports a fixed set of parameter types
+/// on <c>Create</c> methods (<see cref="CancellationToken"/>, <see cref="IDocumentOperations"/>,
+/// the event type, and <see cref="JasperFx.Events.IEvent"/>). <see cref="IServiceProvider"/>
+/// is <b>not</b> supported, so all dependencies are injected via the constructor and temporal
+/// keys are loaded through the supplied <see cref="IDocumentOperations"/>.
 /// </para>
 /// </remarks>
 public sealed class AuditEntryProjection : EventProjection
 {
+    private readonly string _shreddedPlaceholder;
+    private readonly ILogger<AuditEntryProjection> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuditEntryProjection"/> class
+    /// using the default shredded placeholder (<see cref="MartenAuditOptions.DefaultShreddedPlaceholder"/>)
+    /// and a null logger.
+    /// </summary>
+    public AuditEntryProjection()
+        : this(MartenAuditOptions.DefaultShreddedPlaceholder, NullLogger<AuditEntryProjection>.Instance)
+    {
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="AuditEntryProjection"/> class.
     /// </summary>
-    public AuditEntryProjection()
+    /// <param name="shreddedPlaceholder">
+    /// The placeholder substituted for PII fields when the temporal key has been destroyed.
+    /// </param>
+    /// <param name="logger">Logger used for projection diagnostics.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="shreddedPlaceholder"/> or <paramref name="logger"/> is <c>null</c>.
+    /// </exception>
+    public AuditEntryProjection(string shreddedPlaceholder, ILogger<AuditEntryProjection> logger)
     {
+        ArgumentNullException.ThrowIfNull(shreddedPlaceholder);
+        ArgumentNullException.ThrowIfNull(logger);
+
         Name = "AuditEntryProjection";
+        _shreddedPlaceholder = shreddedPlaceholder;
+        _logger = logger;
     }
 
     /// <summary>
     /// Creates an <see cref="AuditEntryReadModel"/> document from an <see cref="AuditEntryRecordedEvent"/>.
     /// </summary>
     /// <param name="event">The event containing the encrypted audit entry data.</param>
-    /// <param name="services">The scoped service provider for resolving dependencies.</param>
+    /// <param name="operations">
+    /// The Marten document operations used to load the temporal key for the entry's period.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The projected read model document with decrypted (or shredded) PII fields.</returns>
     /// <remarks>
     /// Marten invokes this method for each <see cref="AuditEntryRecordedEvent"/> in the event stream.
-    /// The <paramref name="services"/> parameter provides access to the DI container for resolving
-    /// <see cref="ITemporalKeyProvider"/> and <see cref="MartenAuditOptions"/>.
+    /// The method shape is constrained by Marten's projection validator — only
+    /// <see cref="IDocumentOperations"/>, <see cref="CancellationToken"/>, and event parameter
+    /// types are permitted.
     /// </remarks>
     [SuppressMessage("Performance", "CA1822:Mark members as static",
         Justification = "Marten's EventProjection convention requires instance methods for Create/Apply.")]
     public async Task<AuditEntryReadModel> Create(
         AuditEntryRecordedEvent @event,
-        IServiceProvider services)
+        IDocumentOperations operations,
+        CancellationToken cancellationToken)
     {
-        var evt = @event;
-        var keyProvider = services.GetRequiredService<ITemporalKeyProvider>();
-        var options = services.GetRequiredService<IOptions<MartenAuditOptions>>().Value;
-        var logger = services.GetRequiredService<ILogger<AuditEntryProjection>>();
+        ArgumentNullException.ThrowIfNull(@event);
+        ArgumentNullException.ThrowIfNull(operations);
 
-        // Attempt to retrieve the temporal key for decryption
-        byte[]? keyMaterial = null;
-        var isShredded = false;
+        var (keyMaterial, isShredded) = await LoadTemporalKeyAsync(
+            operations, @event.TemporalKeyPeriod, cancellationToken).ConfigureAwait(false);
 
-        var keyResult = await keyProvider.GetKeyAsync(evt.TemporalKeyPeriod)
-            .ConfigureAwait(false);
+        if (isShredded)
+        {
+            _logger.LogDebug(
+                "Temporal key for period {Period} not found — marking audit entry {EntryId} as shredded",
+                @event.TemporalKeyPeriod,
+                @event.Id);
+        }
 
-        keyResult.Match(
-            Right: keyInfo => keyMaterial = keyInfo.KeyMaterial,
-            Left: _ =>
-            {
-                isShredded = true;
-                logger.LogDebug(
-                    "Temporal key for period {Period} not found — marking audit entry {EntryId} as shredded",
-                    evt.TemporalKeyPeriod,
-                    evt.Id);
-            });
+        return MapToReadModel(@event, keyMaterial, isShredded);
+    }
 
-        var placeholder = options.ShreddedPlaceholder;
+    /// <summary>
+    /// Loads the active temporal key material for a given period via Marten's
+    /// <see cref="IQuerySession"/>, honoring the destroyed marker for crypto-shredded periods.
+    /// </summary>
+    /// <remarks>
+    /// This is exposed as <c>internal</c> so unit tests can verify the key-lookup contract
+    /// against an in-memory Marten session or a stub without invoking the full projection pipeline.
+    /// </remarks>
+    internal static async Task<(byte[]? KeyMaterial, bool IsShredded)> LoadTemporalKeyAsync(
+        IQuerySession session,
+        string period,
+        CancellationToken cancellationToken)
+    {
+        var destroyedDoc = await session.LoadAsync<TemporalKeyDestroyedMarker>(
+            TemporalPeriodHelper.FormatDestroyedMarkerId(period),
+            cancellationToken).ConfigureAwait(false);
+
+        if (destroyedDoc is not null)
+        {
+            return (null, true);
+        }
+
+        var activeKeys = await session.Query<TemporalKeyDocument>()
+            .Where(d => d.Period == period && d.Status == TemporalKeyStatus.Active)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        if (activeKeys.Count == 0)
+        {
+            return (null, true);
+        }
+
+        var activeKey = activeKeys.OrderByDescending(k => k.Version).First();
+        return (activeKey.KeyMaterial, false);
+    }
+
+    /// <summary>
+    /// Maps an <see cref="AuditEntryRecordedEvent"/> to an <see cref="AuditEntryReadModel"/>,
+    /// decrypting PII fields with the supplied key material or substituting the shredded
+    /// placeholder when <paramref name="isShredded"/> is <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Exposed as <c>internal</c> so unit tests can validate the mapping logic independently
+    /// of Marten's projection pipeline, which cannot be booted from unit tests.
+    /// </remarks>
+    internal AuditEntryReadModel MapToReadModel(
+        AuditEntryRecordedEvent @event,
+        byte[]? keyMaterial,
+        bool isShredded)
+    {
+        var placeholder = _shreddedPlaceholder;
 
         return new AuditEntryReadModel
         {
             // Identity
-            Id = evt.Id,
+            Id = @event.Id,
 
             // Structural fields (always plaintext)
-            CorrelationId = evt.CorrelationId,
-            Action = evt.Action,
-            EntityType = evt.EntityType,
-            EntityId = evt.EntityId,
-            Outcome = (AuditOutcome)evt.Outcome,
-            ErrorMessage = evt.ErrorMessage,
-            TimestampUtc = evt.TimestampUtc,
-            StartedAtUtc = evt.StartedAtUtc,
-            CompletedAtUtc = evt.CompletedAtUtc,
-            RequestPayloadHash = evt.RequestPayloadHash,
-            TenantId = evt.TenantId,
+            CorrelationId = @event.CorrelationId,
+            Action = @event.Action,
+            EntityType = @event.EntityType,
+            EntityId = @event.EntityId,
+            Outcome = (AuditOutcome)@event.Outcome,
+            ErrorMessage = @event.ErrorMessage,
+            TimestampUtc = @event.TimestampUtc,
+            StartedAtUtc = @event.StartedAtUtc,
+            CompletedAtUtc = @event.CompletedAtUtc,
+            RequestPayloadHash = @event.RequestPayloadHash,
+            TenantId = @event.TenantId,
 
             // PII fields (decrypted or shredded)
-            UserId = evt.EncryptedUserId?.DecryptOrPlaceholder(keyMaterial, placeholder),
-            IpAddress = evt.EncryptedIpAddress?.DecryptOrPlaceholder(keyMaterial, placeholder),
-            UserAgent = evt.EncryptedUserAgent?.DecryptOrPlaceholder(keyMaterial, placeholder),
-            RequestPayload = evt.EncryptedRequestPayload?.DecryptOrPlaceholder(keyMaterial, placeholder),
-            ResponsePayload = evt.EncryptedResponsePayload?.DecryptOrPlaceholder(keyMaterial, placeholder),
-            MetadataJson = evt.EncryptedMetadata?.DecryptOrPlaceholder(keyMaterial, placeholder),
+            UserId = @event.EncryptedUserId?.DecryptOrPlaceholder(keyMaterial, placeholder),
+            IpAddress = @event.EncryptedIpAddress?.DecryptOrPlaceholder(keyMaterial, placeholder),
+            UserAgent = @event.EncryptedUserAgent?.DecryptOrPlaceholder(keyMaterial, placeholder),
+            RequestPayload = @event.EncryptedRequestPayload?.DecryptOrPlaceholder(keyMaterial, placeholder),
+            ResponsePayload = @event.EncryptedResponsePayload?.DecryptOrPlaceholder(keyMaterial, placeholder),
+            MetadataJson = @event.EncryptedMetadata?.DecryptOrPlaceholder(keyMaterial, placeholder),
 
             // Crypto-shredding tracking
             IsShredded = isShredded,
-            TemporalKeyPeriod = evt.TemporalKeyPeriod
+            TemporalKeyPeriod = @event.TemporalKeyPeriod
         };
     }
 }

--- a/src/Encina.Audit.Marten/Projections/ConfigureMartenAuditProjections.cs
+++ b/src/Encina.Audit.Marten/Projections/ConfigureMartenAuditProjections.cs
@@ -1,5 +1,6 @@
 using Marten;
 
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Encina.Audit.Marten.Projections;
@@ -28,17 +29,54 @@ namespace Encina.Audit.Marten.Projections;
 /// <item>Eventual consistency (typically milliseconds to low seconds)</item>
 /// </list>
 /// </para>
+/// <para>
+/// Projection instances are constructed here (not by Marten) so that configured options
+/// (<see cref="MartenAuditOptions.ShreddedPlaceholder"/>) and loggers can be injected via
+/// their constructors. This avoids Marten's projection validator rejecting
+/// <see cref="IServiceProvider"/> parameters on <c>Create</c> methods.
+/// </para>
 /// </remarks>
 internal sealed class ConfigureMartenAuditProjections : IConfigureOptions<StoreOptions>
 {
+    private readonly IOptions<MartenAuditOptions> _auditOptions;
+    private readonly ILoggerFactory _loggerFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigureMartenAuditProjections"/> class.
+    /// </summary>
+    /// <param name="auditOptions">Configured Marten audit options.</param>
+    /// <param name="loggerFactory">Logger factory for creating projection loggers.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="auditOptions"/> or <paramref name="loggerFactory"/> is <c>null</c>.
+    /// </exception>
+    public ConfigureMartenAuditProjections(
+        IOptions<MartenAuditOptions> auditOptions,
+        ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(auditOptions);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        _auditOptions = auditOptions;
+        _loggerFactory = loggerFactory;
+    }
+
     /// <inheritdoc />
     public void Configure(StoreOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        // Register async projections processed by Marten's AsyncProjectionDaemon
-        options.Projections.Add(new AuditEntryProjection(), JasperFx.Events.Projections.ProjectionLifecycle.Async);
-        options.Projections.Add(new ReadAuditEntryProjection(), JasperFx.Events.Projections.ProjectionLifecycle.Async);
+        var placeholder = _auditOptions.Value.ShreddedPlaceholder;
+
+        // Register async projections processed by Marten's AsyncProjectionDaemon.
+        // Projections are constructed with explicit dependencies so Marten's validator
+        // only sees parameters it supports (IDocumentOperations, CancellationToken, event types).
+        options.Projections.Add(
+            new AuditEntryProjection(placeholder, _loggerFactory.CreateLogger<AuditEntryProjection>()),
+            JasperFx.Events.Projections.ProjectionLifecycle.Async);
+
+        options.Projections.Add(
+            new ReadAuditEntryProjection(placeholder, _loggerFactory.CreateLogger<ReadAuditEntryProjection>()),
+            JasperFx.Events.Projections.ProjectionLifecycle.Async);
 
         // Configure indexes for AuditEntryReadModel
         options.Schema.For<AuditEntryReadModel>()

--- a/src/Encina.Audit.Marten/Projections/ReadAuditEntryProjection.cs
+++ b/src/Encina.Audit.Marten/Projections/ReadAuditEntryProjection.cs
@@ -95,14 +95,6 @@ public sealed class ReadAuditEntryProjection : EventProjection
         var (keyMaterial, isShredded) = await AuditEntryProjection.LoadTemporalKeyAsync(
             operations, @event.TemporalKeyPeriod, cancellationToken).ConfigureAwait(false);
 
-        if (isShredded)
-        {
-            _logger.LogDebug(
-                "Temporal key for period {Period} not found — marking read audit entry {EntryId} as shredded",
-                @event.TemporalKeyPeriod,
-                @event.Id);
-        }
-
         return MapToReadModel(@event, keyMaterial, isShredded);
     }
 
@@ -120,6 +112,14 @@ public sealed class ReadAuditEntryProjection : EventProjection
         byte[]? keyMaterial,
         bool isShredded)
     {
+        if (isShredded)
+        {
+            _logger.LogDebug(
+                "Temporal key for period {Period} not found — marking read audit entry {EntryId} as shredded",
+                @event.TemporalKeyPeriod,
+                @event.Id);
+        }
+
         var placeholder = _shreddedPlaceholder;
 
         return new ReadAuditEntryReadModel

--- a/src/Encina.Audit.Marten/Projections/ReadAuditEntryProjection.cs
+++ b/src/Encina.Audit.Marten/Projections/ReadAuditEntryProjection.cs
@@ -4,11 +4,11 @@ using Encina.Audit.Marten.Crypto;
 using Encina.Audit.Marten.Events;
 using Encina.Security.Audit;
 
+using Marten;
 using Marten.Events.Projections;
 
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Encina.Audit.Marten.Projections;
 
@@ -23,18 +23,48 @@ namespace Encina.Audit.Marten.Projections;
 /// </para>
 /// <para>
 /// During processing, the projection decrypts PII fields (UserId, Purpose, Metadata)
-/// using the temporal key for the entry's period. If the key has been destroyed,
-/// PII fields are replaced with <c>[SHREDDED]</c> placeholders.
+/// using the temporal key for the entry's period, loaded through the projection-scoped
+/// <see cref="IDocumentOperations"/>. If the key has been destroyed, PII fields are replaced
+/// with the configured shredded placeholder.
+/// </para>
+/// <para>
+/// <b>Note:</b> Marten's projection validation only supports a fixed set of parameter types
+/// on <c>Create</c> methods. <see cref="IServiceProvider"/> is not supported, so dependencies
+/// are injected via the constructor.
 /// </para>
 /// </remarks>
 public sealed class ReadAuditEntryProjection : EventProjection
 {
+    private readonly string _shreddedPlaceholder;
+    private readonly ILogger<ReadAuditEntryProjection> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReadAuditEntryProjection"/> class
+    /// using the default shredded placeholder and a null logger.
+    /// </summary>
+    public ReadAuditEntryProjection()
+        : this(MartenAuditOptions.DefaultShreddedPlaceholder, NullLogger<ReadAuditEntryProjection>.Instance)
+    {
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ReadAuditEntryProjection"/> class.
     /// </summary>
-    public ReadAuditEntryProjection()
+    /// <param name="shreddedPlaceholder">
+    /// The placeholder substituted for PII fields when the temporal key has been destroyed.
+    /// </param>
+    /// <param name="logger">Logger used for projection diagnostics.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="shreddedPlaceholder"/> or <paramref name="logger"/> is <c>null</c>.
+    /// </exception>
+    public ReadAuditEntryProjection(string shreddedPlaceholder, ILogger<ReadAuditEntryProjection> logger)
     {
+        ArgumentNullException.ThrowIfNull(shreddedPlaceholder);
+        ArgumentNullException.ThrowIfNull(logger);
+
         Name = "ReadAuditEntryProjection";
+        _shreddedPlaceholder = shreddedPlaceholder;
+        _logger = logger;
     }
 
     /// <summary>
@@ -42,61 +72,73 @@ public sealed class ReadAuditEntryProjection : EventProjection
     /// <see cref="ReadAuditEntryRecordedEvent"/>.
     /// </summary>
     /// <param name="event">The event containing the encrypted read audit entry data.</param>
-    /// <param name="services">The scoped service provider for resolving dependencies.</param>
+    /// <param name="operations">
+    /// The Marten document operations used to load the temporal key for the entry's period.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The projected read model document with decrypted (or shredded) PII fields.</returns>
     [SuppressMessage("Performance", "CA1822:Mark members as static",
         Justification = "Marten's EventProjection convention requires instance methods for Create/Apply.")]
     public async Task<ReadAuditEntryReadModel> Create(
         ReadAuditEntryRecordedEvent @event,
-        IServiceProvider services)
+        IDocumentOperations operations,
+        CancellationToken cancellationToken)
     {
-        var evt = @event;
-        var keyProvider = services.GetRequiredService<ITemporalKeyProvider>();
-        var options = services.GetRequiredService<IOptions<MartenAuditOptions>>().Value;
-        var logger = services.GetRequiredService<ILogger<ReadAuditEntryProjection>>();
+        ArgumentNullException.ThrowIfNull(@event);
+        ArgumentNullException.ThrowIfNull(operations);
 
-        // Attempt to retrieve the temporal key for decryption
-        byte[]? keyMaterial = null;
-        var isShredded = false;
+        var (keyMaterial, isShredded) = await AuditEntryProjection.LoadTemporalKeyAsync(
+            operations, @event.TemporalKeyPeriod, cancellationToken).ConfigureAwait(false);
 
-        var keyResult = await keyProvider.GetKeyAsync(evt.TemporalKeyPeriod)
-            .ConfigureAwait(false);
+        if (isShredded)
+        {
+            _logger.LogDebug(
+                "Temporal key for period {Period} not found — marking read audit entry {EntryId} as shredded",
+                @event.TemporalKeyPeriod,
+                @event.Id);
+        }
 
-        keyResult.Match(
-            Right: keyInfo => keyMaterial = keyInfo.KeyMaterial,
-            Left: _ =>
-            {
-                isShredded = true;
-                logger.LogDebug(
-                    "Temporal key for period {Period} not found — marking read audit entry {EntryId} as shredded",
-                    evt.TemporalKeyPeriod,
-                    evt.Id);
-            });
+        return MapToReadModel(@event, keyMaterial, isShredded);
+    }
 
-        var placeholder = options.ShreddedPlaceholder;
+    /// <summary>
+    /// Maps a <see cref="ReadAuditEntryRecordedEvent"/> to a <see cref="ReadAuditEntryReadModel"/>,
+    /// decrypting PII fields with the supplied key material or substituting the shredded
+    /// placeholder when <paramref name="isShredded"/> is <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Exposed as <c>internal</c> so unit tests can validate the mapping logic independently
+    /// of Marten's projection pipeline.
+    /// </remarks>
+    internal ReadAuditEntryReadModel MapToReadModel(
+        ReadAuditEntryRecordedEvent @event,
+        byte[]? keyMaterial,
+        bool isShredded)
+    {
+        var placeholder = _shreddedPlaceholder;
 
         return new ReadAuditEntryReadModel
         {
             // Identity
-            Id = evt.Id,
+            Id = @event.Id,
 
             // Structural fields (always plaintext)
-            EntityType = evt.EntityType,
-            EntityId = evt.EntityId,
-            AccessedAtUtc = evt.AccessedAtUtc,
-            AccessMethod = (ReadAccessMethod)evt.AccessMethod,
-            EntityCount = evt.EntityCount,
-            CorrelationId = evt.CorrelationId,
-            TenantId = evt.TenantId,
+            EntityType = @event.EntityType,
+            EntityId = @event.EntityId,
+            AccessedAtUtc = @event.AccessedAtUtc,
+            AccessMethod = (ReadAccessMethod)@event.AccessMethod,
+            EntityCount = @event.EntityCount,
+            CorrelationId = @event.CorrelationId,
+            TenantId = @event.TenantId,
 
             // PII fields (decrypted or shredded)
-            UserId = evt.EncryptedUserId?.DecryptOrPlaceholder(keyMaterial, placeholder),
-            Purpose = evt.EncryptedPurpose?.DecryptOrPlaceholder(keyMaterial, placeholder),
-            MetadataJson = evt.EncryptedMetadata?.DecryptOrPlaceholder(keyMaterial, placeholder),
+            UserId = @event.EncryptedUserId?.DecryptOrPlaceholder(keyMaterial, placeholder),
+            Purpose = @event.EncryptedPurpose?.DecryptOrPlaceholder(keyMaterial, placeholder),
+            MetadataJson = @event.EncryptedMetadata?.DecryptOrPlaceholder(keyMaterial, placeholder),
 
             // Crypto-shredding tracking
             IsShredded = isShredded,
-            TemporalKeyPeriod = evt.TemporalKeyPeriod
+            TemporalKeyPeriod = @event.TemporalKeyPeriod
         };
     }
 }

--- a/src/Encina.Audit.Marten/Projections/ReadAuditEntryProjection.cs
+++ b/src/Encina.Audit.Marten/Projections/ReadAuditEntryProjection.cs
@@ -54,12 +54,17 @@ public sealed class ReadAuditEntryProjection : EventProjection
     /// The placeholder substituted for PII fields when the temporal key has been destroyed.
     /// </param>
     /// <param name="logger">Logger used for projection diagnostics.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="shreddedPlaceholder"/> is <c>null</c>, empty, or whitespace.
+    /// An empty or whitespace placeholder would project PII fields as blank strings instead
+    /// of masking them, which defeats the purpose of crypto-shredding.
+    /// </exception>
     /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="shreddedPlaceholder"/> or <paramref name="logger"/> is <c>null</c>.
+    /// Thrown when <paramref name="logger"/> is <c>null</c>.
     /// </exception>
     public ReadAuditEntryProjection(string shreddedPlaceholder, ILogger<ReadAuditEntryProjection> logger)
     {
-        ArgumentNullException.ThrowIfNull(shreddedPlaceholder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(shreddedPlaceholder);
         ArgumentNullException.ThrowIfNull(logger);
 
         Name = "ReadAuditEntryProjection";

--- a/src/Encina.Audit.Marten/PublicAPI.Unshipped.txt
+++ b/src/Encina.Audit.Marten/PublicAPI.Unshipped.txt
@@ -121,7 +121,8 @@ Encina.Audit.Marten.Events.ReadAuditEntryRecordedEvent.TenantId.get -> string?
 Encina.Audit.Marten.Events.ReadAuditEntryRecordedEvent.TenantId.init -> void
 Encina.Audit.Marten.Projections.AuditEntryProjection
 Encina.Audit.Marten.Projections.AuditEntryProjection.AuditEntryProjection() -> void
-Encina.Audit.Marten.Projections.AuditEntryProjection.Create(Encina.Audit.Marten.Events.AuditEntryRecordedEvent! event, System.IServiceProvider! services) -> System.Threading.Tasks.Task<Encina.Audit.Marten.Projections.AuditEntryReadModel!>!
+Encina.Audit.Marten.Projections.AuditEntryProjection.AuditEntryProjection(string! shreddedPlaceholder, Microsoft.Extensions.Logging.ILogger<Encina.Audit.Marten.Projections.AuditEntryProjection!>! logger) -> void
+Encina.Audit.Marten.Projections.AuditEntryProjection.Create(Encina.Audit.Marten.Events.AuditEntryRecordedEvent! event, Marten.IDocumentOperations! operations, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Encina.Audit.Marten.Projections.AuditEntryReadModel!>!
 Encina.Audit.Marten.Projections.AuditEntryReadModel
 Encina.Audit.Marten.Projections.AuditEntryReadModel.AuditEntryReadModel() -> void
 Encina.Audit.Marten.Projections.AuditEntryReadModel.Action.get -> string!
@@ -166,7 +167,8 @@ Encina.Audit.Marten.Projections.AuditEntryReadModel.UserId.get -> string?
 Encina.Audit.Marten.Projections.AuditEntryReadModel.UserId.set -> void
 Encina.Audit.Marten.Projections.ReadAuditEntryProjection
 Encina.Audit.Marten.Projections.ReadAuditEntryProjection.ReadAuditEntryProjection() -> void
-Encina.Audit.Marten.Projections.ReadAuditEntryProjection.Create(Encina.Audit.Marten.Events.ReadAuditEntryRecordedEvent! event, System.IServiceProvider! services) -> System.Threading.Tasks.Task<Encina.Audit.Marten.Projections.ReadAuditEntryReadModel!>!
+Encina.Audit.Marten.Projections.ReadAuditEntryProjection.ReadAuditEntryProjection(string! shreddedPlaceholder, Microsoft.Extensions.Logging.ILogger<Encina.Audit.Marten.Projections.ReadAuditEntryProjection!>! logger) -> void
+Encina.Audit.Marten.Projections.ReadAuditEntryProjection.Create(Encina.Audit.Marten.Events.ReadAuditEntryRecordedEvent! event, Marten.IDocumentOperations! operations, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Encina.Audit.Marten.Projections.ReadAuditEntryReadModel!>!
 Encina.Audit.Marten.Projections.ReadAuditEntryReadModel
 Encina.Audit.Marten.Projections.ReadAuditEntryReadModel.ReadAuditEntryReadModel() -> void
 Encina.Audit.Marten.Projections.ReadAuditEntryReadModel.AccessedAtUtc.get -> System.DateTimeOffset

--- a/src/Encina.Audit.Marten/ServiceCollectionExtensions.cs
+++ b/src/Encina.Audit.Marten/ServiceCollectionExtensions.cs
@@ -94,7 +94,13 @@ public static class ServiceCollectionExtensions
         // Ensure TimeProvider is available
         services.TryAddSingleton(TimeProvider.System);
 
-        // Ensure ILoggerFactory is available for projection logger injection
+        // Ensure ILoggerFactory is available for ConfigureMartenAuditProjections to build
+        // typed loggers. AddLogging() is idempotent and pay-for-what-you-use: all of its
+        // internal registrations use TryAdd, so a host that has already configured logging
+        // providers (Console, Serilog, etc.) keeps winning. Using a bare NullLoggerFactory
+        // TryAddSingleton here would introduce a registration-order footgun — if this
+        // extension runs before the host's own AddLogging() call, NullLoggerFactory would
+        // claim the ILoggerFactory slot and silently swallow the host's configured logs.
         services.AddLogging();
 
         // Instantiate options to inspect flags for conditional registrations

--- a/src/Encina.Audit.Marten/ServiceCollectionExtensions.cs
+++ b/src/Encina.Audit.Marten/ServiceCollectionExtensions.cs
@@ -94,6 +94,9 @@ public static class ServiceCollectionExtensions
         // Ensure TimeProvider is available
         services.TryAddSingleton(TimeProvider.System);
 
+        // Ensure ILoggerFactory is available for projection logger injection
+        services.AddLogging();
+
         // Instantiate options to inspect flags for conditional registrations
         var optionsInstance = new MartenAuditOptions();
         configure?.Invoke(optionsInstance);

--- a/tests/Encina.GuardTests/AuditMarten/AuditEntryProjectionGuardTests.cs
+++ b/tests/Encina.GuardTests/AuditMarten/AuditEntryProjectionGuardTests.cs
@@ -1,34 +1,24 @@
-using Encina.Audit.Marten;
-using Encina.Audit.Marten.Crypto;
 using Encina.Audit.Marten.Events;
 using Encina.Audit.Marten.Projections;
-using Encina.Security.Audit;
 
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Time.Testing;
 
 namespace Encina.GuardTests.AuditMarten;
 
 /// <summary>
 /// Guard tests for <see cref="AuditEntryProjection"/> and <see cref="ReadAuditEntryProjection"/>.
-/// Ensures the projection types can be constructed and invoked with a real service provider.
+/// Validates constructor and method null-argument guards.
 /// </summary>
+/// <remarks>
+/// The <c>Create(IDocumentOperations, ...)</c> path cannot be exercised from guard tests because
+/// Marten's <c>IDocumentOperations</c> cannot be faked with a simple stub — the LINQ query
+/// pipeline requires a real Marten document session. End-to-end coverage is provided by the
+/// integration test suite, which boots a real PostgreSQL-backed Marten store.
+/// </remarks>
 public class AuditEntryProjectionGuardTests
 {
-    private static ServiceProvider BuildServiceProvider()
-    {
-        var services = new ServiceCollection();
-        services.AddSingleton<ITemporalKeyProvider>(new InMemoryTemporalKeyProvider(
-            new FakeTimeProvider(new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero)),
-            NullLogger<InMemoryTemporalKeyProvider>.Instance));
-        services.Configure<MartenAuditOptions>(_ => { });
-        services.AddLogging();
-        return services.BuildServiceProvider();
-    }
-
     [Fact]
-    public void AuditEntryProjection_Constructor_DoesNotThrow()
+    public void AuditEntryProjection_Constructor_Parameterless_DoesNotThrow()
     {
         var projection = new AuditEntryProjection();
         projection.ShouldNotBeNull();
@@ -36,23 +26,31 @@ public class AuditEntryProjectionGuardTests
     }
 
     [Fact]
-    public void ReadAuditEntryProjection_Constructor_DoesNotThrow()
+    public void AuditEntryProjection_Constructor_NullPlaceholder_Throws()
     {
-        var projection = new ReadAuditEntryProjection();
-        projection.ShouldNotBeNull();
-        projection.Name.ShouldBe("ReadAuditEntryProjection");
+        Should.Throw<ArgumentNullException>(() =>
+            new AuditEntryProjection(null!, NullLogger<AuditEntryProjection>.Instance));
     }
 
     [Fact]
-    public async Task AuditEntryProjection_Create_MissingKey_ReturnsShredded()
+    public void AuditEntryProjection_Constructor_NullLogger_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new AuditEntryProjection("[SHREDDED]", null!));
+    }
+
+    [Fact]
+    public async Task AuditEntryProjection_Create_NullEvent_Throws()
     {
         var projection = new AuditEntryProjection();
-        var services = BuildServiceProvider();
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await projection.Create(null!, operations: null!, CancellationToken.None));
+    }
 
-        var dummyKey = new byte[32];
-        System.Security.Cryptography.RandomNumberGenerator.Fill(dummyKey);
-        var encrypted = EncryptedField.Encrypt("data", dummyKey, "temporal:9999-12:v1");
-
+    [Fact]
+    public async Task AuditEntryProjection_Create_NullOperations_Throws()
+    {
+        var projection = new AuditEntryProjection();
         var evt = new AuditEntryRecordedEvent
         {
             Id = Guid.NewGuid(),
@@ -63,41 +61,59 @@ public class AuditEntryProjectionGuardTests
             TimestampUtc = DateTime.UtcNow,
             StartedAtUtc = DateTimeOffset.UtcNow,
             CompletedAtUtc = DateTimeOffset.UtcNow,
-            EncryptedUserId = encrypted,
-            TemporalKeyPeriod = "9999-12"
+            TemporalKeyPeriod = "2026-03"
         };
 
-        var result = await projection.Create(evt, services);
-
-        result.IsShredded.ShouldBeTrue();
-        result.UserId.ShouldBe("[SHREDDED]");
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await projection.Create(evt, operations: null!, CancellationToken.None));
     }
 
     [Fact]
-    public async Task ReadAuditEntryProjection_Create_MissingKey_ReturnsShredded()
+    public void ReadAuditEntryProjection_Constructor_Parameterless_DoesNotThrow()
     {
         var projection = new ReadAuditEntryProjection();
-        var services = BuildServiceProvider();
+        projection.ShouldNotBeNull();
+        projection.Name.ShouldBe("ReadAuditEntryProjection");
+    }
 
-        var dummyKey = new byte[32];
-        System.Security.Cryptography.RandomNumberGenerator.Fill(dummyKey);
-        var encrypted = EncryptedField.Encrypt("data", dummyKey, "temporal:9999-12:v1");
+    [Fact]
+    public void ReadAuditEntryProjection_Constructor_NullPlaceholder_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ReadAuditEntryProjection(null!, NullLogger<ReadAuditEntryProjection>.Instance));
+    }
 
+    [Fact]
+    public void ReadAuditEntryProjection_Constructor_NullLogger_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ReadAuditEntryProjection("[SHREDDED]", null!));
+    }
+
+    [Fact]
+    public async Task ReadAuditEntryProjection_Create_NullEvent_Throws()
+    {
+        var projection = new ReadAuditEntryProjection();
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await projection.Create(null!, operations: null!, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ReadAuditEntryProjection_Create_NullOperations_Throws()
+    {
+        var projection = new ReadAuditEntryProjection();
         var evt = new ReadAuditEntryRecordedEvent
         {
             Id = Guid.NewGuid(),
             EntityType = "E",
             EntityId = null,
             AccessedAtUtc = DateTimeOffset.UtcNow,
-            AccessMethod = (int)ReadAccessMethod.Repository,
+            AccessMethod = 0,
             EntityCount = 0,
-            EncryptedUserId = encrypted,
-            TemporalKeyPeriod = "9999-12"
+            TemporalKeyPeriod = "2026-03"
         };
 
-        var result = await projection.Create(evt, services);
-
-        result.IsShredded.ShouldBeTrue();
-        result.UserId.ShouldBe("[SHREDDED]");
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await projection.Create(evt, operations: null!, CancellationToken.None));
     }
 }

--- a/tests/Encina.UnitTests/AuditMarten/AuditEntryProjectionTests.cs
+++ b/tests/Encina.UnitTests/AuditMarten/AuditEntryProjectionTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 using Encina.Audit.Marten;
 using Encina.Audit.Marten.Crypto;
 using Encina.Audit.Marten.Events;
@@ -25,10 +27,37 @@ public sealed class AuditEntryProjectionTests
         new(placeholder, NullLogger<AuditEntryProjection>.Instance);
 
     [Fact]
-    public void Constructor_Parameterless_SetsNameAndDefaults()
+    public void Constructor_Parameterless_SetsNameAndUsesDefaultShreddedPlaceholder()
     {
+        // Arrange: parameterless ctor should fall back to MartenAuditOptions.DefaultShreddedPlaceholder
         var projection = new AuditEntryProjection();
+
+        var evt = new AuditEntryRecordedEvent
+        {
+            Id = Guid.NewGuid(),
+            CorrelationId = "c",
+            Action = "a",
+            EntityType = "E",
+            Outcome = 0,
+            TimestampUtc = DateTime.UtcNow,
+            StartedAtUtc = DateTimeOffset.UtcNow,
+            CompletedAtUtc = DateTimeOffset.UtcNow,
+            // Field encrypted with a random throw-away key; key material is not supplied
+            // to MapToReadModel so the shredded branch must fire.
+            EncryptedUserId = EncryptedField.Encrypt(
+                "secret",
+                RandomNumberGenerator.GetBytes(32),
+                "temporal:2026-03:v1"),
+            TemporalKeyPeriod = "2026-03"
+        };
+
+        // Act
+        var readModel = projection.MapToReadModel(evt, keyMaterial: null, isShredded: true);
+
+        // Assert: the default placeholder propagates from the parameterless constructor
         projection.Name.ShouldBe("AuditEntryProjection");
+        readModel.UserId.ShouldBe(MartenAuditOptions.DefaultShreddedPlaceholder);
+        readModel.IsShredded.ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/Encina.UnitTests/AuditMarten/AuditEntryProjectionTests.cs
+++ b/tests/Encina.UnitTests/AuditMarten/AuditEntryProjectionTests.cs
@@ -222,6 +222,103 @@ public sealed class AuditEntryProjectionTests
     }
 
     [Fact]
+    public void ClassifyTemporalKeyLookup_WithActiveKey_ReturnsKeyMaterialAndNotShredded()
+    {
+        // Arrange
+        var keyMaterial = RandomNumberGenerator.GetBytes(32);
+        var activeKey = new TemporalKeyDocument
+        {
+            Id = "temporal:2026-03:v2",
+            Period = "2026-03",
+            KeyMaterial = keyMaterial,
+            Version = 2,
+            Status = TemporalKeyStatus.Active,
+            CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        // Act
+        var (resultKey, isShredded) = AuditEntryProjection.ClassifyTemporalKeyLookup(
+            activeKey, destroyedMarker: null, "2026-03");
+
+        // Assert
+        resultKey.ShouldBeSameAs(keyMaterial);
+        isShredded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ClassifyTemporalKeyLookup_WithNoActiveKeyButDestroyedMarker_ReturnsShredded()
+    {
+        // Arrange: simulates a period that was explicitly crypto-shredded via DestroyKeysBeforeAsync.
+        var destroyedMarker = new TemporalKeyDestroyedMarker
+        {
+            Id = "temporal-destroyed:2020-01",
+            Period = "2020-01",
+            DestroyedAtUtc = DateTimeOffset.UtcNow,
+            KeyVersionsDestroyed = 3
+        };
+
+        // Act
+        var (resultKey, isShredded) = AuditEntryProjection.ClassifyTemporalKeyLookup(
+            activeKey: null, destroyedMarker, "2020-01");
+
+        // Assert
+        resultKey.ShouldBeNull();
+        isShredded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ClassifyTemporalKeyLookup_WithNeitherActiveKeyNorDestroyedMarker_ThrowsKeyNotFound()
+    {
+        // Arrange: simulates transient inconsistency — no active key written yet AND no
+        // destroyed marker. This MUST throw so the Marten async daemon retries on the next
+        // pass instead of persisting a read model with IsShredded=true (which would advance
+        // the high-water mark and permanently corrupt the read model).
+        // Act + Assert
+        var ex = Should.Throw<KeyNotFoundException>(() =>
+            AuditEntryProjection.ClassifyTemporalKeyLookup(
+                activeKey: null, destroyedMarker: null, "2026-03"));
+
+        ex.Message.ShouldContain("2026-03");
+        ex.Message.ShouldContain("transient inconsistency");
+        ex.Message.ShouldContain("retry");
+    }
+
+    [Fact]
+    public void ClassifyTemporalKeyLookup_ActiveKey_TakesPrecedenceOverDestroyedMarker()
+    {
+        // Arrange: defensive — if both exist (e.g., a new key was issued after a prior
+        // shredding cycle for a future period), the active key wins. The current projection
+        // logic only fetches the destroyed marker when the active-key lookup came up empty,
+        // so this path is not reachable from LoadTemporalKeyAsync, but ClassifyTemporalKeyLookup
+        // is still defensively correct when called with both arguments non-null.
+        var keyMaterial = RandomNumberGenerator.GetBytes(32);
+        var activeKey = new TemporalKeyDocument
+        {
+            Id = "temporal:2026-03:v1",
+            Period = "2026-03",
+            KeyMaterial = keyMaterial,
+            Version = 1,
+            Status = TemporalKeyStatus.Active,
+            CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+        var destroyedMarker = new TemporalKeyDestroyedMarker
+        {
+            Id = "temporal-destroyed:2026-03",
+            Period = "2026-03",
+            DestroyedAtUtc = DateTimeOffset.UtcNow,
+            KeyVersionsDestroyed = 1
+        };
+
+        // Act
+        var (resultKey, isShredded) = AuditEntryProjection.ClassifyTemporalKeyLookup(
+            activeKey, destroyedMarker, "2026-03");
+
+        // Assert
+        resultKey.ShouldBeSameAs(keyMaterial);
+        isShredded.ShouldBeFalse();
+    }
+
+    [Fact]
     public void MapToReadModel_UsesCustomShreddedPlaceholder()
     {
         // Arrange

--- a/tests/Encina.UnitTests/AuditMarten/AuditEntryProjectionTests.cs
+++ b/tests/Encina.UnitTests/AuditMarten/AuditEntryProjectionTests.cs
@@ -4,61 +4,63 @@ using Encina.Audit.Marten.Events;
 using Encina.Audit.Marten.Projections;
 using Encina.Security.Audit;
 
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Time.Testing;
 
 namespace Encina.UnitTests.AuditMarten;
 
 /// <summary>
 /// Unit tests for <see cref="AuditEntryProjection"/> event-to-read-model projection logic.
 /// </summary>
+/// <remarks>
+/// These tests exercise the internal mapping helpers (<c>MapToReadModel</c>) directly. The
+/// full <c>Create(IDocumentOperations, ...)</c> path cannot be exercised from unit tests
+/// because it requires a real Marten document store to run the projection daemon — that
+/// coverage belongs to the integration test suite.
+/// </remarks>
 [Trait("Category", "Unit")]
 [Trait("Provider", "Marten")]
 public sealed class AuditEntryProjectionTests
 {
-    private static ServiceProvider BuildServices(InMemoryTemporalKeyProvider keyProvider, MartenAuditOptions? options = null)
-    {
-        var services = new ServiceCollection();
-        services.AddSingleton<ITemporalKeyProvider>(keyProvider);
-        services.Configure<MartenAuditOptions>(o =>
-        {
-            var cfg = options ?? new MartenAuditOptions();
-            o.TemporalGranularity = cfg.TemporalGranularity;
-            o.EncryptionScope = cfg.EncryptionScope;
-            o.RetentionPeriod = cfg.RetentionPeriod;
-            o.ShreddedPlaceholder = cfg.ShreddedPlaceholder;
-            o.EnableAutoPurge = cfg.EnableAutoPurge;
-            o.PurgeIntervalHours = cfg.PurgeIntervalHours;
-        });
-        services.AddLogging();
-        return services.BuildServiceProvider();
-    }
-
-    private static InMemoryTemporalKeyProvider CreateKeyProvider(FakeTimeProvider? time = null) =>
-        new(time ?? new FakeTimeProvider(new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero)),
-            NullLogger<InMemoryTemporalKeyProvider>.Instance);
+    private static AuditEntryProjection CreateProjection(string placeholder = "[SHREDDED]") =>
+        new(placeholder, NullLogger<AuditEntryProjection>.Instance);
 
     [Fact]
-    public void Constructor_SetsName()
+    public void Constructor_Parameterless_SetsNameAndDefaults()
     {
         var projection = new AuditEntryProjection();
         projection.Name.ShouldBe("AuditEntryProjection");
     }
 
     [Fact]
-    public async Task Create_WithValidKey_DecryptsPiiFields()
+    public void Constructor_WithPlaceholderAndLogger_SetsName()
+    {
+        var projection = CreateProjection("<HIDDEN>");
+        projection.Name.ShouldBe("AuditEntryProjection");
+    }
+
+    [Fact]
+    public void Constructor_NullPlaceholder_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new AuditEntryProjection(null!, NullLogger<AuditEntryProjection>.Instance));
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new AuditEntryProjection("[SHREDDED]", null!));
+    }
+
+    [Fact]
+    public void MapToReadModel_WithValidKey_DecryptsPiiFields()
     {
         // Arrange
-        var keyProvider = CreateKeyProvider();
-        var keyResult = await keyProvider.GetOrCreateKeyAsync("2026-03");
-        byte[] keyMaterial = null!;
-        string keyId = null!;
-        keyResult.IfRight(k => { keyMaterial = k.KeyMaterial; keyId = k.KeyId; });
+        var keyMaterial = new byte[32];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(keyMaterial);
+        var keyId = "temporal:2026-03:v1";
 
-        var services = BuildServices(keyProvider);
-        var projection = new AuditEntryProjection();
-
+        var projection = CreateProjection();
         var evt = new AuditEntryRecordedEvent
         {
             Id = Guid.NewGuid(),
@@ -83,7 +85,7 @@ public sealed class AuditEntryProjectionTests
         };
 
         // Act
-        var readModel = await projection.Create(evt, services);
+        var readModel = projection.MapToReadModel(evt, keyMaterial, isShredded: false);
 
         // Assert
         readModel.ShouldNotBeNull();
@@ -105,19 +107,14 @@ public sealed class AuditEntryProjectionTests
     }
 
     [Fact]
-    public async Task Create_WithMissingKey_ReturnsShreddedModel()
+    public void MapToReadModel_WithShreddedKey_ReturnsShreddedPlaceholder()
     {
         // Arrange
-        var keyProvider = CreateKeyProvider();
-        // DO NOT create key for "2099-12" - it will be shredded
-        var services = BuildServices(keyProvider);
-        var projection = new AuditEntryProjection();
-
-        // Encrypt using a different key that won't be found
         var dummyKey = new byte[32];
         System.Security.Cryptography.RandomNumberGenerator.Fill(dummyKey);
         var encrypted = EncryptedField.Encrypt("secret", dummyKey, "temporal:2099-12:v1");
 
+        var projection = CreateProjection();
         var evt = new AuditEntryRecordedEvent
         {
             Id = Guid.NewGuid(),
@@ -141,8 +138,8 @@ public sealed class AuditEntryProjectionTests
             TemporalKeyPeriod = "2099-12"
         };
 
-        // Act
-        var readModel = await projection.Create(evt, services);
+        // Act: pass null key material and isShredded=true as the Create method would
+        var readModel = projection.MapToReadModel(evt, keyMaterial: null, isShredded: true);
 
         // Assert
         readModel.IsShredded.ShouldBeTrue();
@@ -152,14 +149,13 @@ public sealed class AuditEntryProjectionTests
     }
 
     [Fact]
-    public async Task Create_WithNullEncryptedFields_ReturnsModelWithNulls()
+    public void MapToReadModel_WithNullEncryptedFields_ReturnsModelWithNulls()
     {
         // Arrange
-        var keyProvider = CreateKeyProvider();
-        await keyProvider.GetOrCreateKeyAsync("2026-03");
-        var services = BuildServices(keyProvider);
-        var projection = new AuditEntryProjection();
+        var keyMaterial = new byte[32];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(keyMaterial);
 
+        var projection = CreateProjection();
         var evt = new AuditEntryRecordedEvent
         {
             Id = Guid.NewGuid(),
@@ -184,7 +180,7 @@ public sealed class AuditEntryProjectionTests
         };
 
         // Act
-        var readModel = await projection.Create(evt, services);
+        var readModel = projection.MapToReadModel(evt, keyMaterial, isShredded: false);
 
         // Assert
         readModel.UserId.ShouldBeNull();
@@ -197,18 +193,14 @@ public sealed class AuditEntryProjectionTests
     }
 
     [Fact]
-    public async Task Create_UsesCustomShreddedPlaceholder()
+    public void MapToReadModel_UsesCustomShreddedPlaceholder()
     {
         // Arrange
-        var keyProvider = CreateKeyProvider();
-        var options = new MartenAuditOptions { ShreddedPlaceholder = "<REDACTED>" };
-        var services = BuildServices(keyProvider, options);
-        var projection = new AuditEntryProjection();
-
         var dummyKey = new byte[32];
         System.Security.Cryptography.RandomNumberGenerator.Fill(dummyKey);
         var encrypted = EncryptedField.Encrypt("secret", dummyKey, "temporal:1999-01:v1");
 
+        var projection = CreateProjection("<REDACTED>");
         var evt = new AuditEntryRecordedEvent
         {
             Id = Guid.NewGuid(),
@@ -224,7 +216,7 @@ public sealed class AuditEntryProjectionTests
         };
 
         // Act
-        var readModel = await projection.Create(evt, services);
+        var readModel = projection.MapToReadModel(evt, keyMaterial: null, isShredded: true);
 
         // Assert
         readModel.UserId.ShouldBe("<REDACTED>");

--- a/tests/Encina.UnitTests/AuditMarten/ConfigureMartenAuditProjectionsTests.cs
+++ b/tests/Encina.UnitTests/AuditMarten/ConfigureMartenAuditProjectionsTests.cs
@@ -66,32 +66,36 @@ public sealed class ConfigureMartenAuditProjectionsTests
     }
 
     [Fact]
-    public void Configure_ValidOptions_RegistersAuditProjections()
+    public void Configure_ValidOptions_PassesMartenProjectionValidation()
     {
         // Arrange
         var sut = CreateSut();
         var storeOptions = new StoreOptions();
 
-        // Act — this is the call that previously threw InvalidProjectionException
+        // Act + Assert: this is the exact call that previously threw InvalidProjectionException
         // at Marten's projection validation layer because Create() took IServiceProvider.
-        // With the fix it must complete without throwing.
-        sut.Configure(storeOptions);
-
-        // Assert: the configurator should run to completion. Marten does not expose a simple
-        // public count of registered projections prior to store initialization, so we rely on
-        // absence-of-exception plus the downstream integration test suite to verify the
-        // projection graph itself.
+        // The regression signal for #949 is simply that StoreOptions.Projections.Add(...) —
+        // invoked from inside Configure — runs to completion for BOTH audit projections.
+        //
+        // Marten does not expose a public, stable way to enumerate registered projections/mappings
+        // on a bare StoreOptions instance (the real state materializes at DocumentStore.For()
+        // time), so the projection graph itself is exercised end-to-end by the integration test
+        // suite tracked in #951. For unit-level regression locking, not-throwing is the precise
+        // inverse of the bug.
+        Should.NotThrow(() => sut.Configure(storeOptions));
     }
 
     [Fact]
-    public void Configure_UsesCustomShreddedPlaceholder()
+    public void Configure_CustomShreddedPlaceholder_PassesMartenProjectionValidation()
     {
         // Arrange
         var options = new MartenAuditOptions { ShreddedPlaceholder = "<REDACTED>" };
         var sut = CreateSut(options);
         var storeOptions = new StoreOptions();
 
-        // Act — must not throw even when a non-default placeholder is configured.
-        sut.Configure(storeOptions);
+        // Act + Assert: a non-default placeholder must not change the JasperFx validation result.
+        // This guards against future refactors that might accidentally couple the placeholder to
+        // a validator-rejected parameter type on the projection Create methods.
+        Should.NotThrow(() => sut.Configure(storeOptions));
     }
 }

--- a/tests/Encina.UnitTests/AuditMarten/ConfigureMartenAuditProjectionsTests.cs
+++ b/tests/Encina.UnitTests/AuditMarten/ConfigureMartenAuditProjectionsTests.cs
@@ -1,4 +1,10 @@
+using Encina.Audit.Marten;
 using Encina.Audit.Marten.Projections;
+
+using Marten;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace Encina.UnitTests.AuditMarten;
 
@@ -6,25 +12,86 @@ namespace Encina.UnitTests.AuditMarten;
 /// Unit tests for <see cref="ConfigureMartenAuditProjections"/> Marten store option configurator.
 /// </summary>
 /// <remarks>
-/// Only the null-guard path is validated in unit tests. The full Configure path requires a
-/// real Marten store initialization (integration-level) because Marten's projection validation
-/// requires a DocumentStore context that cannot be faked.
+/// <para>
+/// These tests validate constructor guards and that <see cref="ConfigureMartenAuditProjections.Configure"/>
+/// registers projections and indexes without throwing. Previously, this type could not be tested
+/// end-to-end because projections took <see cref="IServiceProvider"/> as a parameter — Marten's
+/// projection validator rejected that at store initialization time, which is why #949 was silently
+/// broken in production.
+/// </para>
+/// <para>
+/// With the fix, projections accept only parameter types supported by Marten
+/// (<see cref="IDocumentOperations"/>, <see cref="CancellationToken"/>, and the event type), so
+/// <see cref="ConfigureMartenAuditProjections.Configure"/> can be exercised here against a plain
+/// <see cref="StoreOptions"/> instance without booting a real PostgreSQL store.
+/// </para>
 /// </remarks>
 [Trait("Category", "Unit")]
 [Trait("Provider", "Marten")]
 public sealed class ConfigureMartenAuditProjectionsTests
 {
+    private static ConfigureMartenAuditProjections CreateSut(MartenAuditOptions? options = null) =>
+        new(
+            Options.Create(options ?? new MartenAuditOptions()),
+            NullLoggerFactory.Instance);
+
+    [Fact]
+    public void Constructor_NullAuditOptions_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ConfigureMartenAuditProjections(null!, NullLoggerFactory.Instance));
+    }
+
+    [Fact]
+    public void Constructor_NullLoggerFactory_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ConfigureMartenAuditProjections(
+                Options.Create(new MartenAuditOptions()),
+                null!));
+    }
+
+    [Fact]
+    public void Constructor_WithValidDependencies_CreatesInstance()
+    {
+        var sut = CreateSut();
+        sut.ShouldNotBeNull();
+    }
+
     [Fact]
     public void Configure_NullOptions_ThrowsArgumentNullException()
     {
-        var sut = new ConfigureMartenAuditProjections();
+        var sut = CreateSut();
         Should.Throw<ArgumentNullException>(() => sut.Configure(null!));
     }
 
     [Fact]
-    public void Constructor_CreatesInstance()
+    public void Configure_ValidOptions_RegistersAuditProjections()
     {
-        var sut = new ConfigureMartenAuditProjections();
-        sut.ShouldNotBeNull();
+        // Arrange
+        var sut = CreateSut();
+        var storeOptions = new StoreOptions();
+
+        // Act — this is the call that previously threw InvalidProjectionException
+        // at Marten's projection validation layer because Create() took IServiceProvider.
+        // With the fix it must complete without throwing.
+        sut.Configure(storeOptions);
+
+        // Assert: the configurator should run to completion. Marten does not expose a simple
+        // public count of registered projections prior to store initialization, so we rely on
+        // absence-of-exception plus the downstream integration test suite to verify the
+        // projection graph itself.
+    }
+
+    [Fact]
+    public void Configure_UsesCustomShreddedPlaceholder()
+    {
+        // Arrange
+        var options = new MartenAuditOptions { ShreddedPlaceholder = "<REDACTED>" };
+        var sut = CreateSut(options);
+        var storeOptions = new StoreOptions();
+
+        // Act — must not throw even when a non-default placeholder is configured.
+        sut.Configure(storeOptions);
     }
 }

--- a/tests/Encina.UnitTests/AuditMarten/ReadAuditEntryProjectionTests.cs
+++ b/tests/Encina.UnitTests/AuditMarten/ReadAuditEntryProjectionTests.cs
@@ -4,56 +4,62 @@ using Encina.Audit.Marten.Events;
 using Encina.Audit.Marten.Projections;
 using Encina.Security.Audit;
 
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Time.Testing;
 
 namespace Encina.UnitTests.AuditMarten;
 
 /// <summary>
 /// Unit tests for <see cref="ReadAuditEntryProjection"/> read-audit event projection logic.
 /// </summary>
+/// <remarks>
+/// These tests exercise the internal mapping helper (<c>MapToReadModel</c>) directly. The
+/// full <c>Create(IDocumentOperations, ...)</c> path is covered by integration tests that
+/// boot a real Marten store.
+/// </remarks>
 [Trait("Category", "Unit")]
 [Trait("Provider", "Marten")]
 public sealed class ReadAuditEntryProjectionTests
 {
-    private static ServiceProvider BuildServices(InMemoryTemporalKeyProvider keyProvider, MartenAuditOptions? options = null)
-    {
-        var services = new ServiceCollection();
-        services.AddSingleton<ITemporalKeyProvider>(keyProvider);
-        services.Configure<MartenAuditOptions>(o =>
-        {
-            var cfg = options ?? new MartenAuditOptions();
-            o.ShreddedPlaceholder = cfg.ShreddedPlaceholder;
-        });
-        services.AddLogging();
-        return services.BuildServiceProvider();
-    }
-
-    private static InMemoryTemporalKeyProvider CreateKeyProvider() =>
-        new(new FakeTimeProvider(new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero)),
-            NullLogger<InMemoryTemporalKeyProvider>.Instance);
+    private static ReadAuditEntryProjection CreateProjection(string placeholder = "[SHREDDED]") =>
+        new(placeholder, NullLogger<ReadAuditEntryProjection>.Instance);
 
     [Fact]
-    public void Constructor_SetsName()
+    public void Constructor_Parameterless_SetsName()
     {
         var projection = new ReadAuditEntryProjection();
         projection.Name.ShouldBe("ReadAuditEntryProjection");
     }
 
     [Fact]
-    public async Task Create_WithValidKey_DecryptsPiiFields()
+    public void Constructor_WithPlaceholderAndLogger_SetsName()
+    {
+        var projection = CreateProjection("<HIDDEN>");
+        projection.Name.ShouldBe("ReadAuditEntryProjection");
+    }
+
+    [Fact]
+    public void Constructor_NullPlaceholder_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ReadAuditEntryProjection(null!, NullLogger<ReadAuditEntryProjection>.Instance));
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_ThrowsArgumentNullException()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ReadAuditEntryProjection("[SHREDDED]", null!));
+    }
+
+    [Fact]
+    public void MapToReadModel_WithValidKey_DecryptsPiiFields()
     {
         // Arrange
-        var keyProvider = CreateKeyProvider();
-        var keyResult = await keyProvider.GetOrCreateKeyAsync("2026-03");
-        byte[] keyMaterial = null!;
-        string keyId = null!;
-        keyResult.IfRight(k => { keyMaterial = k.KeyMaterial; keyId = k.KeyId; });
+        var keyMaterial = new byte[32];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(keyMaterial);
+        var keyId = "temporal:2026-03:v1";
 
-        var services = BuildServices(keyProvider);
-        var projection = new ReadAuditEntryProjection();
-
+        var projection = CreateProjection();
         var evt = new ReadAuditEntryRecordedEvent
         {
             Id = Guid.NewGuid(),
@@ -71,7 +77,7 @@ public sealed class ReadAuditEntryProjectionTests
         };
 
         // Act
-        var readModel = await projection.Create(evt, services);
+        var readModel = projection.MapToReadModel(evt, keyMaterial, isShredded: false);
 
         // Assert
         readModel.ShouldNotBeNull();
@@ -90,17 +96,14 @@ public sealed class ReadAuditEntryProjectionTests
     }
 
     [Fact]
-    public async Task Create_WithMissingKey_ReturnsShreddedModel()
+    public void MapToReadModel_WithShreddedKey_ReturnsShreddedPlaceholder()
     {
         // Arrange
-        var keyProvider = CreateKeyProvider();
-        var services = BuildServices(keyProvider);
-        var projection = new ReadAuditEntryProjection();
-
         var dummyKey = new byte[32];
         System.Security.Cryptography.RandomNumberGenerator.Fill(dummyKey);
         var encrypted = EncryptedField.Encrypt("user", dummyKey, "temporal:2099-12:v1");
 
+        var projection = CreateProjection();
         var evt = new ReadAuditEntryRecordedEvent
         {
             Id = Guid.NewGuid(),
@@ -118,7 +121,7 @@ public sealed class ReadAuditEntryProjectionTests
         };
 
         // Act
-        var readModel = await projection.Create(evt, services);
+        var readModel = projection.MapToReadModel(evt, keyMaterial: null, isShredded: true);
 
         // Assert
         readModel.IsShredded.ShouldBeTrue();
@@ -127,14 +130,13 @@ public sealed class ReadAuditEntryProjectionTests
     }
 
     [Fact]
-    public async Task Create_WithNullEncryptedFields_ReturnsModelWithNulls()
+    public void MapToReadModel_WithNullEncryptedFields_ReturnsModelWithNulls()
     {
         // Arrange
-        var keyProvider = CreateKeyProvider();
-        await keyProvider.GetOrCreateKeyAsync("2026-03");
-        var services = BuildServices(keyProvider);
-        var projection = new ReadAuditEntryProjection();
+        var keyMaterial = new byte[32];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(keyMaterial);
 
+        var projection = CreateProjection();
         var evt = new ReadAuditEntryRecordedEvent
         {
             Id = Guid.NewGuid(),
@@ -150,7 +152,7 @@ public sealed class ReadAuditEntryProjectionTests
         };
 
         // Act
-        var readModel = await projection.Create(evt, services);
+        var readModel = projection.MapToReadModel(evt, keyMaterial, isShredded: false);
 
         // Assert
         readModel.UserId.ShouldBeNull();


### PR DESCRIPTION
## Summary

- Replaces `IServiceProvider` with `IDocumentOperations` in `AuditEntryProjection.Create` / `ReadAuditEntryProjection.Create` so Marten's JasperFx projection validator stops rejecting the projections at store boot (#949)
- Moves `ShreddedPlaceholder` and `ILogger` into projection constructors and wires them through `ConfigureMartenAuditProjections`
- Restores the `Configure_ValidOptions_RegistersAuditProjections` regression-locking test that was removed in #948 because the bug made it unreachable

## Fixes #949

## Test plan

- [x] `dotnet build src/Encina.Audit.Marten -c Release` — 0 warnings, 0 errors
- [x] `dotnet test tests/Encina.UnitTests --filter FullyQualifiedName~AuditMarten` — 124 passed, 1 skipped (load test)
- [x] `dotnet test tests/Encina.GuardTests --filter FullyQualifiedName~AuditMarten` — 83 passed
- [ ] CI green

## Follow-ups (tracked separately)

- #951 — `[TEST] Encina.Audit.Marten integration tests — real Marten store end-to-end` (closes the test-infra gap that allowed #949 to ship)
- #952 — `[DEBT] Audit Encina.Marten.GDPR projections for IServiceProvider parameter anti-pattern` (check for the same bug elsewhere)

Both added to EPIC #871 (v0.13.4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de la Versión

* **Refactor**
  * Proyecciones de auditoría ahora reciben placeholder y logger por constructor y usan operaciones de documento en Create.

* **Correcciones de Errores**
  * Validación reforzada de argumentos nulos; lookup de claves temporales devuelve resultado explícito para clave activa, marcador destruido o error cuando falta.

* **Mejoras**
  * Mapeo centralizado para descifrado o sustitución por placeholder; logging reducido a casos relevantes; registro asegurado en la configuración.

* **Tests**
  * Pruebas adaptadas a constructores y MapToReadModel; cobertura ampliada para validaciones y escenarios de clave temporal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->