### PR TITLE
test(cdc): fix coverage manifest and close guard/property gaps

### DIFF
--- a/.github/coverage-manifest/Encina.Cdc.json
+++ b/.github/coverage-manifest/Encina.Cdc.json
@@ -1,55 +1,49 @@
 {
   "package": "Encina.Cdc",
-  "generated": "2026-03-27T12:05:17Z",
+  "generated": "2026-04-11T00:00:00Z",
   "totalFiles": 51,
   "targets": {
     "guard": 15,
-    "integration": 10,
     "property": 10,
     "unit": 50
   },
   "files": {
     "Abstractions/CdcPosition.cs": {
       "defaultTests": [
-        "unit",
-        "guard",
-        "property"
+        "unit"
       ],
-      "defaultRule": "*CdcPosition.cs",
-      "reason": "Position serialization with round-trip invariant"
+      "defaultRule": "*.cs",
+      "reason": "Abstract base with only abstract methods — no coverable lines for guard/property, contract is verified via concrete subclasses"
     },
     "Abstractions/ICdcConnector.cs": {
       "defaultTests": [],
       "defaultRule": "^I[A-Z].*\\.cs$",
-      "reason": "Interfaces have no implementation to test"
+      "reason": "Interface — no implementation to test"
     },
     "Abstractions/ICdcDispatcher.cs": {
       "defaultTests": [],
       "defaultRule": "^I[A-Z].*\\.cs$",
-      "reason": "Interfaces have no implementation to test"
+      "reason": "Interface — no implementation to test"
     },
     "Abstractions/ICdcPositionStore.cs": {
       "defaultTests": [],
       "defaultRule": "^I[A-Z].*\\.cs$",
-      "reason": "Interfaces have no implementation to test"
+      "reason": "Interface — no implementation to test"
     },
     "Abstractions/IChangeEventHandler.cs": {
-      "defaultTests": [
-        "unit",
-        "guard"
-      ],
-      "defaultRule": "*Handler.cs",
-      "reason": "Handler with mockeable dependencies"
+      "defaultTests": [],
+      "defaultRule": "^I[A-Z].*\\.cs$",
+      "reason": "Interface — no implementation to test"
     },
     "Abstractions/IShardedCdcConnector.cs": {
       "defaultTests": [],
       "defaultRule": "^I[A-Z].*\\.cs$",
-      "reason": "Interfaces have no implementation to test"
+      "reason": "Interface — no implementation to test"
     },
     "Abstractions/IShardedCdcPositionStore.cs": {
       "defaultTests": [],
       "defaultRule": "^I[A-Z].*\\.cs$",
-      "reason": "Interfaces have no implementation to test"
+      "reason": "Interface — no implementation to test"
     },
     "Caching/CacheInvalidationSubscriberHealthCheck.cs": {
       "defaultTests": [
@@ -57,31 +51,30 @@
         "guard"
       ],
       "defaultRule": "*HealthCheck.cs",
-      "reason": "Health check with mockeable service dependencies"
+      "reason": "Health check with constructor null guards and mockeable service dependencies"
     },
     "Caching/CacheInvalidationSubscriberService.cs": {
       "defaultTests": [
         "unit",
         "guard"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Service.cs",
+      "reason": "Hosted service with constructor null guards and mockeable pub/sub dependency"
     },
     "Caching/CdcCacheInvalidationLog.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Log.cs",
+      "reason": "LoggerMessage source-generated file — no guards, no invariants"
     },
     "Caching/CdcTableNameResolver.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "property"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Resolver.cs",
+      "reason": "Pure function with invariants: mapping precedence, schema stripping, case-insensitive matching"
     },
     "Caching/Diagnostics/CacheInvalidationActivitySource.cs": {
       "defaultTests": [
@@ -103,99 +96,94 @@
         "guard"
       ],
       "defaultRule": "*Handler.cs",
-      "reason": "Handler with mockeable dependencies"
+      "reason": "Handler with constructor null guards and mockeable dependencies"
     },
     "Caching/QueryCacheInvalidationOptions.cs": {
       "defaultTests": [
-        "unit"
+        "unit",
+        "property"
       ],
       "defaultRule": "*Options.cs",
-      "reason": "Configuration POCO with defaults and validation"
+      "reason": "Configuration POCO with default-value invariants and filter/mapping semantics"
     },
     "CdcConfiguration.cs": {
       "defaultTests": [
-        "unit"
+        "unit",
+        "guard"
       ],
       "defaultRule": "*Configuration.cs",
-      "reason": "EF entity type configuration"
+      "reason": "Fluent builder with argument guards on public methods"
     },
     "CdcLog.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Log.cs",
+      "reason": "LoggerMessage source-generated file — no guards, no invariants"
     },
     "CdcOptions.cs": {
       "defaultTests": [
-        "unit"
+        "unit",
+        "property"
       ],
       "defaultRule": "*Options.cs",
-      "reason": "Configuration POCO with defaults and validation"
+      "reason": "Configuration POCO with defaults, ranges, and invariants (batch size, retries, intervals, filter behavior)"
     },
     "ChangeContext.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
       "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "reason": "Positional record — no guard clauses to test, invariants trivially hold by construction"
     },
     "ChangeEvent.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
       "defaultRule": "*Event.cs",
-      "reason": "Domain event"
+      "reason": "Positional record — no guard clauses to test, invariants trivially hold by construction"
     },
     "ChangeMetadata.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
       "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "reason": "Positional record — no guard clauses to test, invariants trivially hold by construction"
     },
     "ChangeOperation.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
       "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "reason": "Enum — no executable code, guard/property not applicable"
     },
     "DeadLetter/CdcDeadLetterEntry.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Entry.cs",
+      "reason": "Positional record — no guard clauses to test, invariants trivially hold by construction"
     },
     "DeadLetter/CdcDeadLetterHealthCheckOptions.cs": {
       "defaultTests": [
         "unit"
       ],
       "defaultRule": "*Options.cs",
-      "reason": "Configuration POCO with defaults and validation"
+      "reason": "Configuration POCO with default values, no invariants beyond defaults"
     },
     "DeadLetter/CdcDeadLetterResolution.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
       "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "reason": "Enum — no executable code, guard/property not applicable"
     },
     "DeadLetter/CdcDeadLetterStatus.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
       "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "reason": "Enum — no executable code, guard/property not applicable"
     },
     "DeadLetter/Diagnostics/CdcDeadLetterMetrics.cs": {
       "defaultTests": [
@@ -207,29 +195,30 @@
     "DeadLetter/ICdcDeadLetterStore.cs": {
       "defaultTests": [],
       "defaultRule": "^I[A-Z].*\\.cs$",
-      "reason": "Interfaces have no implementation to test"
+      "reason": "Interface — no implementation to test"
     },
     "DeadLetter/InMemoryCdcDeadLetterStore.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "guard",
+        "property"
       ],
       "defaultRule": "*Store.cs",
-      "reason": "Abstract/base store with mockeable deps"
+      "reason": "In-memory store with add/get/resolve round-trip invariants, status-transition invariants, and null/argument guards"
     },
     "Errors/CdcErrorCodes.cs": {
       "defaultTests": [
         "unit"
       ],
       "defaultRule": "*ErrorCodes.cs",
-      "reason": "Error code constants"
+      "reason": "Error code constants — no guards, no invariants"
     },
     "Errors/CdcErrors.cs": {
       "defaultTests": [
         "unit"
       ],
       "defaultRule": "*Errors.cs",
-      "reason": "Static error factory methods"
+      "reason": "Static error factory methods — covered by unit tests that verify message shape and codes"
     },
     "Health/CdcDeadLetterHealthCheck.cs": {
       "defaultTests": [
@@ -237,7 +226,7 @@
         "guard"
       ],
       "defaultRule": "*HealthCheck.cs",
-      "reason": "Health check with mockeable service dependencies"
+      "reason": "Health check with constructor null guards and mockeable service dependencies"
     },
     "Health/CdcHealthCheck.cs": {
       "defaultTests": [
@@ -245,7 +234,7 @@
         "guard"
       ],
       "defaultRule": "*HealthCheck.cs",
-      "reason": "Health check with mockeable service dependencies"
+      "reason": "Health check with constructor null guards and mockeable service dependencies"
     },
     "Health/ShardedCdcHealthCheck.cs": {
       "defaultTests": [
@@ -253,43 +242,44 @@
         "guard"
       ],
       "defaultRule": "*HealthCheck.cs",
-      "reason": "Health check with mockeable service dependencies"
+      "reason": "Health check with constructor null guards and mockeable service dependencies"
     },
     "Messaging/CdcChangeNotification.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "guard",
+        "property"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Notification.cs",
+      "reason": "Notification with FromChangeEvent placeholder substitution invariants (tableName/operation/shardId) and argument guards"
     },
     "Messaging/CdcMessagingBridge.cs": {
       "defaultTests": [
         "unit",
         "guard"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Bridge.cs",
+      "reason": "Bridge service with constructor null guards and mockeable messaging dependencies"
     },
     "Messaging/CdcMessagingLog.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Log.cs",
+      "reason": "LoggerMessage source-generated file — no guards, no invariants"
     },
     "Messaging/CdcMessagingOptions.cs": {
       "defaultTests": [
-        "unit"
+        "unit",
+        "property"
       ],
       "defaultRule": "*Options.cs",
-      "reason": "Configuration POCO with defaults and validation"
+      "reason": "Options with ShouldPublish filter invariants: exclude precedence, include intersection, case-insensitive matching"
     },
     "Messaging/ICdcEventInterceptor.cs": {
       "defaultTests": [],
       "defaultRule": "^I[A-Z].*\\.cs$",
-      "reason": "Interfaces have no implementation to test"
+      "reason": "Interface — no implementation to test"
     },
     "Messaging/OutboxCdcHandler.cs": {
       "defaultTests": [
@@ -297,39 +287,41 @@
         "guard"
       ],
       "defaultRule": "*Handler.cs",
-      "reason": "Handler with mockeable dependencies"
+      "reason": "Handler with constructor null guards and mockeable dependencies"
     },
     "Processing/CdcDispatcher.cs": {
       "defaultTests": [
         "unit",
         "guard"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Dispatcher.cs",
+      "reason": "Dispatcher with constructor null guards and mockeable dependencies"
     },
     "Processing/CdcProcessor.cs": {
       "defaultTests": [
         "unit",
         "guard"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Processor.cs",
+      "reason": "Background processor with constructor null guards and mockeable dependencies"
     },
     "Processing/InMemoryCdcPositionStore.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "guard",
+        "property"
       ],
       "defaultRule": "*Store.cs",
-      "reason": "Abstract/base store with mockeable deps"
+      "reason": "In-memory store with save-then-get round-trip, case-insensitive connector ID, and delete-then-get invariants"
     },
     "Processing/InMemoryShardedCdcPositionStore.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "guard",
+        "property"
       ],
       "defaultRule": "*Store.cs",
-      "reason": "Abstract/base store with mockeable deps"
+      "reason": "In-memory sharded store with composite key (shard, connector) round-trip and case-insensitive matching invariants"
     },
     "ServiceCollectionExtensions.cs": {
       "defaultTests": [
@@ -337,15 +329,14 @@
         "guard"
       ],
       "defaultRule": "*Extensions.cs",
-      "reason": "ServiceCollection extensions with conditional registration"
+      "reason": "ServiceCollection extensions with null guards on services parameter and conditional registration"
     },
     "ShardedChangeEvent.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
       "defaultRule": "*Event.cs",
-      "reason": "Domain event"
+      "reason": "Positional record — no guard clauses to test, invariants trivially hold by construction"
     },
     "Sharding/CdcDrivenRefreshHandler.cs": {
       "defaultTests": [
@@ -353,37 +344,37 @@
         "guard"
       ],
       "defaultRule": "*Handler.cs",
-      "reason": "Handler with mockeable dependencies"
+      "reason": "Handler with constructor null guards and mockeable dependencies"
     },
     "Sharding/ShardedCaptureOptions.cs": {
       "defaultTests": [
         "unit"
       ],
       "defaultRule": "*Options.cs",
-      "reason": "Configuration POCO with defaults and validation"
+      "reason": "Configuration POCO with default values"
     },
     "Sharding/ShardedCdcConnector.cs": {
       "defaultTests": [
-        "integration"
+        "unit",
+        "guard"
       ],
-      "defaultRule": "*CdcConnector.cs",
-      "reason": "CDC connector needs real database with replication"
+      "defaultRule": "*Connector.cs",
+      "reason": "Pure in-memory aggregator over child ICdcConnector instances — tested with fake connectors. Integration tests not applicable (see tests/Encina.IntegrationTests/Cdc/Sharding/ShardedCdcIntegrationTests.md)"
     },
     "Sharding/ShardedCdcProcessor.cs": {
       "defaultTests": [
         "unit",
         "guard"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Processor.cs",
+      "reason": "Background processor with constructor null guards and mockeable dependencies"
     },
     "Sharding/ShardedProcessingMode.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
       "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "reason": "Enum — no executable code, guard/property not applicable"
     }
   }
 }

--- a/tests/Encina.GuardTests/Cdc/CdcHappyPathAndConstructorGuardTests.cs
+++ b/tests/Encina.GuardTests/Cdc/CdcHappyPathAndConstructorGuardTests.cs
@@ -1,0 +1,444 @@
+using Encina.Caching;
+using Encina.Cdc;
+using Encina.Cdc.Abstractions;
+using Encina.Cdc.Caching;
+using Encina.Cdc.DeadLetter;
+using Encina.Cdc.Health;
+using Encina.Cdc.Messaging;
+using Encina.Cdc.Processing;
+using Encina.Cdc.Sharding;
+using Encina.Sharding.ReferenceTables;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using NSubstitute;
+
+using Shouldly;
+
+namespace Encina.GuardTests.Cdc;
+
+/// <summary>
+/// Guard tests covering constructor null guards for Encina.Cdc service classes whose guard
+/// coverage was previously absent: health checks, processors, handlers, stores and services.
+///
+/// These tests target the files marked "guard" in .github/coverage-manifest/Encina.Cdc.json
+/// that previously had no dedicated guard test file.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class CdcHappyPathAndConstructorGuardTests
+{
+    // ─── CdcDeadLetterHealthCheck ───
+
+    [Fact]
+    public void CdcDeadLetterHealthCheck_NullStore_Throws()
+    {
+        var options = new CdcDeadLetterHealthCheckOptions();
+        Should.Throw<ArgumentNullException>(() => new CdcDeadLetterHealthCheck(null!, options));
+    }
+
+    [Fact]
+    public void CdcDeadLetterHealthCheck_NullOptions_Throws()
+    {
+        var store = Substitute.For<ICdcDeadLetterStore>();
+        Should.Throw<ArgumentNullException>(() => new CdcDeadLetterHealthCheck(store, null!));
+    }
+
+    [Fact]
+    public void CdcDeadLetterHealthCheck_ValidArgs_Constructs()
+    {
+        var store = Substitute.For<ICdcDeadLetterStore>();
+        var options = new CdcDeadLetterHealthCheckOptions();
+
+        var sut = new CdcDeadLetterHealthCheck(store, options);
+
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── ShardedCdcHealthCheck ───
+
+    [Fact]
+    public void ShardedCdcHealthCheck_NullConnector_Throws()
+    {
+        var store = Substitute.For<IShardedCdcPositionStore>();
+        Should.Throw<ArgumentNullException>(() => new ShardedCdcHealthCheck(null!, store));
+    }
+
+    [Fact]
+    public void ShardedCdcHealthCheck_NullPositionStore_Throws()
+    {
+        var connector = Substitute.For<IShardedCdcConnector>();
+        Should.Throw<ArgumentNullException>(() => new ShardedCdcHealthCheck(connector, null!));
+    }
+
+    [Fact]
+    public void ShardedCdcHealthCheck_ValidArgs_Constructs()
+    {
+        var connector = Substitute.For<IShardedCdcConnector>();
+        var store = Substitute.For<IShardedCdcPositionStore>();
+
+        var sut = new ShardedCdcHealthCheck(connector, store);
+
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void ShardedCdcHealthCheck_WithProviderTags_Constructs()
+    {
+        var connector = Substitute.For<IShardedCdcConnector>();
+        var store = Substitute.For<IShardedCdcPositionStore>();
+
+        var sut = new ShardedCdcHealthCheck(connector, store, ["custom-tag"]);
+
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── CacheInvalidationSubscriberHealthCheck ───
+
+    [Fact]
+    public void CacheInvalidationSubscriberHealthCheck_NullPubSubProvider_Throws()
+    {
+        var options = Options.Create(new QueryCacheInvalidationOptions());
+        Should.Throw<ArgumentNullException>(() =>
+            new CacheInvalidationSubscriberHealthCheck(null!, options));
+    }
+
+    [Fact]
+    public void CacheInvalidationSubscriberHealthCheck_NullOptions_Throws()
+    {
+        var pubSub = Substitute.For<IPubSubProvider>();
+        Should.Throw<ArgumentNullException>(() =>
+            new CacheInvalidationSubscriberHealthCheck(pubSub, null!));
+    }
+
+    [Fact]
+    public void CacheInvalidationSubscriberHealthCheck_ValidArgs_Constructs()
+    {
+        var pubSub = Substitute.For<IPubSubProvider>();
+        var options = Options.Create(new QueryCacheInvalidationOptions());
+
+        var sut = new CacheInvalidationSubscriberHealthCheck(pubSub, options);
+
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── CacheInvalidationSubscriberService ───
+
+    [Fact]
+    public void CacheInvalidationSubscriberService_NullPubSubProvider_Throws()
+    {
+        var cache = Substitute.For<ICacheProvider>();
+        var options = Options.Create(new QueryCacheInvalidationOptions());
+
+        Should.Throw<ArgumentNullException>(() => new CacheInvalidationSubscriberService(
+            null!,
+            cache,
+            options,
+            NullLogger<CacheInvalidationSubscriberService>.Instance));
+    }
+
+    [Fact]
+    public void CacheInvalidationSubscriberService_NullCacheProvider_Throws()
+    {
+        var pubSub = Substitute.For<IPubSubProvider>();
+        var options = Options.Create(new QueryCacheInvalidationOptions());
+
+        Should.Throw<ArgumentNullException>(() => new CacheInvalidationSubscriberService(
+            pubSub,
+            null!,
+            options,
+            NullLogger<CacheInvalidationSubscriberService>.Instance));
+    }
+
+    [Fact]
+    public void CacheInvalidationSubscriberService_NullOptions_Throws()
+    {
+        var pubSub = Substitute.For<IPubSubProvider>();
+        var cache = Substitute.For<ICacheProvider>();
+
+        Should.Throw<ArgumentNullException>(() => new CacheInvalidationSubscriberService(
+            pubSub,
+            cache,
+            null!,
+            NullLogger<CacheInvalidationSubscriberService>.Instance));
+    }
+
+    [Fact]
+    public void CacheInvalidationSubscriberService_NullLogger_Throws()
+    {
+        var pubSub = Substitute.For<IPubSubProvider>();
+        var cache = Substitute.For<ICacheProvider>();
+        var options = Options.Create(new QueryCacheInvalidationOptions());
+
+        Should.Throw<ArgumentNullException>(() => new CacheInvalidationSubscriberService(
+            pubSub,
+            cache,
+            options,
+            null!));
+    }
+
+    [Fact]
+    public void CacheInvalidationSubscriberService_ValidArgs_Constructs()
+    {
+        var pubSub = Substitute.For<IPubSubProvider>();
+        var cache = Substitute.For<ICacheProvider>();
+        var options = Options.Create(new QueryCacheInvalidationOptions());
+
+        var sut = new CacheInvalidationSubscriberService(
+            pubSub,
+            cache,
+            options,
+            NullLogger<CacheInvalidationSubscriberService>.Instance);
+
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── OutboxCdcHandler ───
+
+    [Fact]
+    public void OutboxCdcHandler_NullEncina_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new OutboxCdcHandler(null!, NullLogger<OutboxCdcHandler>.Instance));
+    }
+
+    [Fact]
+    public void OutboxCdcHandler_NullLogger_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        Should.Throw<ArgumentNullException>(() => new OutboxCdcHandler(encina, null!));
+    }
+
+    [Fact]
+    public void OutboxCdcHandler_ValidArgs_Constructs()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new OutboxCdcHandler(encina, NullLogger<OutboxCdcHandler>.Instance);
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── CdcProcessor ───
+
+    [Fact]
+    public void CdcProcessor_NullServiceProvider_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => new CdcProcessor(
+            null!,
+            NullLogger<CdcProcessor>.Instance,
+            new CdcOptions()));
+    }
+
+    [Fact]
+    public void CdcProcessor_NullLogger_Throws()
+    {
+        var sp = Substitute.For<IServiceProvider>();
+        Should.Throw<ArgumentNullException>(() => new CdcProcessor(sp, null!, new CdcOptions()));
+    }
+
+    [Fact]
+    public void CdcProcessor_NullOptions_Throws()
+    {
+        var sp = Substitute.For<IServiceProvider>();
+        Should.Throw<ArgumentNullException>(() => new CdcProcessor(
+            sp,
+            NullLogger<CdcProcessor>.Instance,
+            null!));
+    }
+
+    [Fact]
+    public void CdcProcessor_ValidArgs_Constructs()
+    {
+        var sp = Substitute.For<IServiceProvider>();
+        var sut = new CdcProcessor(sp, NullLogger<CdcProcessor>.Instance, new CdcOptions());
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── ShardedCdcProcessor ───
+
+    [Fact]
+    public void ShardedCdcProcessor_NullServiceProvider_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => new ShardedCdcProcessor(
+            null!,
+            NullLogger<ShardedCdcProcessor>.Instance,
+            new CdcOptions()));
+    }
+
+    [Fact]
+    public void ShardedCdcProcessor_NullLogger_Throws()
+    {
+        var sp = Substitute.For<IServiceProvider>();
+        Should.Throw<ArgumentNullException>(() => new ShardedCdcProcessor(sp, null!, new CdcOptions()));
+    }
+
+    [Fact]
+    public void ShardedCdcProcessor_NullOptions_Throws()
+    {
+        var sp = Substitute.For<IServiceProvider>();
+        Should.Throw<ArgumentNullException>(() => new ShardedCdcProcessor(
+            sp,
+            NullLogger<ShardedCdcProcessor>.Instance,
+            null!));
+    }
+
+    [Fact]
+    public void ShardedCdcProcessor_ValidArgs_Constructs()
+    {
+        var sp = Substitute.For<IServiceProvider>();
+        var sut = new ShardedCdcProcessor(sp, NullLogger<ShardedCdcProcessor>.Instance, new CdcOptions());
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── CdcHealthCheck (via derived test subclass to exercise protected ctor) ───
+
+    [Fact]
+    public void CdcHealthCheck_DerivedNullConnector_Throws()
+    {
+        var store = Substitute.For<ICdcPositionStore>();
+        Should.Throw<ArgumentNullException>(() => new DerivedCdcHealthCheck(null!, store));
+    }
+
+    [Fact]
+    public void CdcHealthCheck_DerivedNullPositionStore_Throws()
+    {
+        var connector = Substitute.For<ICdcConnector>();
+        Should.Throw<ArgumentNullException>(() => new DerivedCdcHealthCheck(connector, null!));
+    }
+
+    [Fact]
+    public void CdcHealthCheck_DerivedValidArgs_Constructs()
+    {
+        var connector = Substitute.For<ICdcConnector>();
+        var store = Substitute.For<ICdcPositionStore>();
+        var sut = new DerivedCdcHealthCheck(connector, store);
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── InMemoryCdcDeadLetterStore (internal) ───
+
+    [Fact]
+    public async Task InMemoryCdcDeadLetterStore_AddThenGetPending_ReturnsEntry()
+    {
+        var store = new InMemoryCdcDeadLetterStore();
+        var entry = new CdcDeadLetterEntry(
+            Id: Guid.NewGuid(),
+            OriginalEvent: new ChangeEvent(
+                "Orders",
+                ChangeOperation.Insert,
+                null,
+                new { Id = 1 },
+                new ChangeMetadata(new TestCdcPosition(1), DateTime.UtcNow, null, null, null)),
+            ErrorMessage: "failure",
+            StackTrace: "stack",
+            RetryCount: 3,
+            FailedAtUtc: DateTime.UtcNow,
+            ConnectorId: "test",
+            Status: CdcDeadLetterStatus.Pending);
+
+        var addResult = await store.AddAsync(entry);
+        addResult.IsRight.ShouldBeTrue();
+
+        var pending = await store.GetPendingAsync(10);
+        pending.IsRight.ShouldBeTrue();
+        pending.IfRight(list => list.Count.ShouldBe(1));
+    }
+
+    [Fact]
+    public async Task InMemoryCdcDeadLetterStore_ResolveUnknownEntry_ReturnsError()
+    {
+        var store = new InMemoryCdcDeadLetterStore();
+        var result = await store.ResolveAsync(Guid.NewGuid(), CdcDeadLetterResolution.Replay);
+        result.IsLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task InMemoryCdcDeadLetterStore_ResolveTwice_SecondReturnsError()
+    {
+        var store = new InMemoryCdcDeadLetterStore();
+        var entry = new CdcDeadLetterEntry(
+            Id: Guid.NewGuid(),
+            OriginalEvent: new ChangeEvent(
+                "Orders",
+                ChangeOperation.Insert,
+                null,
+                null,
+                new ChangeMetadata(new TestCdcPosition(1), DateTime.UtcNow, null, null, null)),
+            ErrorMessage: "err",
+            StackTrace: "st",
+            RetryCount: 1,
+            FailedAtUtc: DateTime.UtcNow,
+            ConnectorId: "c",
+            Status: CdcDeadLetterStatus.Pending);
+
+        await store.AddAsync(entry);
+
+        var first = await store.ResolveAsync(entry.Id, CdcDeadLetterResolution.Discard);
+        first.IsRight.ShouldBeTrue();
+
+        var second = await store.ResolveAsync(entry.Id, CdcDeadLetterResolution.Discard);
+        second.IsLeft.ShouldBeTrue();
+    }
+
+    // ─── CdcDrivenRefreshHandler (internal) ───
+
+    [Fact]
+    public void CdcDrivenRefreshHandler_NullReplicator_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() => new CdcDrivenRefreshHandler<TestEntity>(
+            null!,
+            NullLogger<CdcDrivenRefreshHandler<TestEntity>>.Instance));
+    }
+
+    [Fact]
+    public void CdcDrivenRefreshHandler_NullLogger_Throws()
+    {
+        var replicator = Substitute.For<IReferenceTableReplicator>();
+        Should.Throw<ArgumentNullException>(() => new CdcDrivenRefreshHandler<TestEntity>(replicator, null!));
+    }
+
+    [Fact]
+    public void CdcDrivenRefreshHandler_ValidArgs_Constructs()
+    {
+        var replicator = Substitute.For<IReferenceTableReplicator>();
+        var sut = new CdcDrivenRefreshHandler<TestEntity>(
+            replicator,
+            NullLogger<CdcDrivenRefreshHandler<TestEntity>>.Instance);
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── ServiceCollectionExtensions guard ───
+
+    [Fact]
+    public void AddEncinaCdc_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaCdc(_ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaCdc_NullConfigure_Throws()
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentNullException>(() => services.AddEncinaCdc(null!));
+    }
+
+    // ─── Test helpers ───
+
+    private sealed class DerivedCdcHealthCheck : CdcHealthCheck
+    {
+        public DerivedCdcHealthCheck(ICdcConnector connector, ICdcPositionStore positionStore)
+            : base("derived-test", connector, positionStore)
+        {
+        }
+    }
+
+    private sealed class TestEntity;
+
+    private sealed class TestCdcPosition(long value) : CdcPosition
+    {
+        public long Value { get; } = value;
+        public override byte[] ToBytes() => BitConverter.GetBytes(Value);
+        public override int CompareTo(CdcPosition? other) => other is TestCdcPosition t ? Value.CompareTo(t.Value) : 1;
+        public override string ToString() => Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+}


### PR DESCRIPTION
## Summary
Fix the Encina.Cdc coverage manifest to reflect real per-line test applicability, then close the resulting gaps.

### Manifest audit (file-by-file)
The previous manifest was inconsistent with the real code. Notably it set `property: 10%` but marked only `Abstractions/CdcPosition.cs` (an abstract class with 0 coverable lines) with the property flag, producing 0 obligations and 0 target — as the user pointed out.

Corrections:
- **Remove `property`** from `CdcPosition.cs` (abstract, no coverable lines).
- **Remove `integration`** from `Sharding/ShardedCdcConnector.cs` (pure in-memory aggregator per the existing `ShardedCdcIntegrationTests.md` justification). Replace with `unit+guard`.
- **Remove `guard`** from positional records (ChangeContext, ChangeEvent, ChangeMetadata, ShardedChangeEvent, CdcDeadLetterEntry), enums (ChangeOperation, CdcDeadLetterResolution, CdcDeadLetterStatus, ShardedProcessingMode) and LoggerMessage source-generated logs (CdcLog, CdcCacheInvalidationLog, CdcMessagingLog) — they have no guard clauses.
- **Add `property`** to files with real invariants that already had matching property tests but weren't credited: `CdcOptions`, `CdcTableNameResolver`, `QueryCacheInvalidationOptions`, `CdcChangeNotification`, `CdcMessagingOptions`, `InMemoryCdcPositionStore`, `InMemoryShardedCdcPositionStore`, `InMemoryCdcDeadLetterStore`.
- **Drop `integration`** from the targets map entirely (no file requires it).

### New guard tests
`tests/Encina.GuardTests/Cdc/CdcHappyPathAndConstructorGuardTests.cs` (37 tests) covers constructor null guards and happy-path construction for:
- CdcDeadLetterHealthCheck, ShardedCdcHealthCheck, CacheInvalidationSubscriberHealthCheck
- CacheInvalidationSubscriberService, OutboxCdcHandler, CdcProcessor, ShardedCdcProcessor
- CdcHealthCheck (via DerivedCdcHealthCheck subclass)
- InMemoryCdcDeadLetterStore (Add/GetPending/Resolve x2/Resolve unknown)
- CdcDrivenRefreshHandler<T>
- ServiceCollectionExtensions.AddEncinaCdc (both guards)

## Test plan
- [x] `dotnet build tests/Encina.GuardTests` — 0 warnings
- [x] GuardTests Cdc: **141** passed (was 104), 0 failed
- [x] PropertyTests Cdc: **123** passed, 0 failed
- [ ] CI Full measures final coverage after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Se añadió una nueva suite de pruebas para mejorar la cobertura de componentes, validando la inicialización correcta y el manejo de entradas inválidas.

* **Chores**
  * Se actualizó la configuración de control de calidad para alinear mejor las estrategias de prueba con la arquitectura del sistema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->