### PR TITLE
test(amazon-sqs): close guard coverage gap

### DIFF
--- a/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
+++ b/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
@@ -1,0 +1,162 @@
+using Amazon.SimpleNotificationService;
+using Amazon.SQS;
+
+using Encina.AmazonSQS;
+using Encina.AmazonSQS.Health;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using NSubstitute;
+
+using Shouldly;
+
+namespace Encina.GuardTests.AmazonSQS;
+
+/// <summary>
+/// Guard tests for Encina.AmazonSQS covering constructor and method null guards
+/// for <see cref="AmazonSQSMessagePublisher"/>, <see cref="AmazonSQSHealthCheck"/>,
+/// <see cref="ServiceCollectionExtensions"/>, and <see cref="EncinaAmazonSQSOptions"/>.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class AmazonSQSGuardTests
+{
+    private static readonly IAmazonSQS SqsClient = Substitute.For<IAmazonSQS>();
+    private static readonly IAmazonSimpleNotificationService SnsClient = Substitute.For<IAmazonSimpleNotificationService>();
+    private static readonly IOptions<EncinaAmazonSQSOptions> Options =
+        Microsoft.Extensions.Options.Options.Create(new EncinaAmazonSQSOptions());
+
+    // ─── AmazonSQSMessagePublisher constructor guards ───
+
+    [Fact]
+    public void Constructor_NullSqsClient_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new AmazonSQSMessagePublisher(null!, SnsClient,
+                NullLogger<AmazonSQSMessagePublisher>.Instance, Options));
+    }
+
+    [Fact]
+    public void Constructor_NullSnsClient_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new AmazonSQSMessagePublisher(SqsClient, null!,
+                NullLogger<AmazonSQSMessagePublisher>.Instance, Options));
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new AmazonSQSMessagePublisher(SqsClient, SnsClient, null!, Options));
+    }
+
+    [Fact]
+    public void Constructor_NullOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new AmazonSQSMessagePublisher(SqsClient, SnsClient,
+                NullLogger<AmazonSQSMessagePublisher>.Instance, null!));
+    }
+
+    [Fact]
+    public void Constructor_ValidArgs_Constructs()
+    {
+        var sut = new AmazonSQSMessagePublisher(SqsClient, SnsClient,
+            NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── AmazonSQSMessagePublisher method guards ───
+
+    [Fact]
+    public async Task SendToQueueAsync_NullMessage_Throws()
+    {
+        var sut = new AmazonSQSMessagePublisher(SqsClient, SnsClient,
+            NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.SendToQueueAsync<object>(null!));
+    }
+
+    [Fact]
+    public async Task PublishToTopicAsync_NullMessage_Throws()
+    {
+        var sut = new AmazonSQSMessagePublisher(SqsClient, SnsClient,
+            NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.PublishToTopicAsync<object>(null!));
+    }
+
+    [Fact]
+    public async Task SendBatchAsync_NullMessages_Throws()
+    {
+        var sut = new AmazonSQSMessagePublisher(SqsClient, SnsClient,
+            NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.SendBatchAsync<object>(null!));
+    }
+
+    [Fact]
+    public async Task SendToFifoQueueAsync_NullMessage_Throws()
+    {
+        var sut = new AmazonSQSMessagePublisher(SqsClient, SnsClient,
+            NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.SendToFifoQueueAsync<object>(null!, "group-1"));
+    }
+
+    [Fact]
+    public async Task SendToFifoQueueAsync_NullMessageGroupId_Throws()
+    {
+        var sut = new AmazonSQSMessagePublisher(SqsClient, SnsClient,
+            NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.SendToFifoQueueAsync(new { Id = 1 }, null!));
+    }
+
+    // ─── AmazonSQSHealthCheck ───
+
+    [Fact]
+    public void AmazonSQSHealthCheck_Constructs()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var sut = new AmazonSQSHealthCheck(sp, null);
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── ServiceCollectionExtensions ───
+
+    [Fact]
+    public void AddEncinaAmazonSQS_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaAmazonSQS(_ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaAmazonSQS_ValidServices_Registers()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(SqsClient);
+        services.AddSingleton(SnsClient);
+
+        var result = services.AddEncinaAmazonSQS(_ => { });
+        result.ShouldNotBeNull();
+    }
+
+    // ─── EncinaAmazonSQSOptions defaults ───
+
+    [Fact]
+    public void EncinaAmazonSQSOptions_Defaults()
+    {
+        var options = new EncinaAmazonSQSOptions();
+        options.ShouldNotBeNull();
+    }
+}

--- a/tests/Encina.GuardTests/Encina.GuardTests.csproj
+++ b/tests/Encina.GuardTests/Encina.GuardTests.csproj
@@ -166,6 +166,7 @@
     <ProjectReference Include="..\..\src\Encina.Testing.FsCheck\Encina.Testing.FsCheck.csproj" />
     <ProjectReference Include="..\..\src\Encina.Testing.Architecture\Encina.Testing.Architecture.csproj" />
     <ProjectReference Include="..\..\src\Encina.Testing.WireMock\Encina.Testing.WireMock.csproj" />
+    <ProjectReference Include="..\..\src\Encina.AmazonSQS\Encina.AmazonSQS.csproj" />
     <ProjectReference Include="..\..\src\Encina.Testing.Pact\Encina.Testing.Pact.csproj" />
     <ProjectReference Include="..\Encina.TestInfrastructure\Encina.TestInfrastructure.csproj" />
 


### PR DESCRIPTION
## Summary
Close the guard coverage gap for `Encina.AmazonSQS`. Unit was 94.93% but guard had 0 data.

### New guard tests
`AmazonSQSGuardTests.cs` (14 tests):
- **AmazonSQSMessagePublisher**: 4 constructor null guards (sqsClient, snsClient, logger, options) + valid construction + 5 method null guards (SendToQueueAsync, PublishToTopicAsync, SendBatchAsync, SendToFifoQueueAsync message + messageGroupId)
- **AmazonSQSHealthCheck**: construction with null options
- **ServiceCollectionExtensions**: null services guard + happy path
- **EncinaAmazonSQSOptions**: defaults

## Test plan
- [x] GuardTests AmazonSQS: **14** passed (was 0)
- [ ] CI Full measures coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Tests**
  * Se han añadido pruebas exhaustivas para validar el comportamiento de componentes Amazon SQS, incluyendo validación de argumentos nulos en constructores y métodos.
  * Las nuevas pruebas garantizan que el sistema rechace correctamente configuraciones inválidas y valores nulos en operaciones críticas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->