### PR TITLE
test(graphql): close guard coverage gap

### DIFF
--- a/tests/Encina.GuardTests/Encina.GuardTests.csproj
+++ b/tests/Encina.GuardTests/Encina.GuardTests.csproj
@@ -167,6 +167,7 @@
     <ProjectReference Include="..\..\src\Encina.Testing.Architecture\Encina.Testing.Architecture.csproj" />
     <ProjectReference Include="..\..\src\Encina.Testing.WireMock\Encina.Testing.WireMock.csproj" />
     <ProjectReference Include="..\..\src\Encina.AmazonSQS\Encina.AmazonSQS.csproj" />
+    <ProjectReference Include="..\..\src\Encina.GraphQL\Encina.GraphQL.csproj" />
     <ProjectReference Include="..\..\src\Encina.Testing.Pact\Encina.Testing.Pact.csproj" />
     <ProjectReference Include="..\Encina.TestInfrastructure\Encina.TestInfrastructure.csproj" />
 

--- a/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
+++ b/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
@@ -1,0 +1,226 @@
+using Encina.GraphQL;
+using Encina.GraphQL.Pagination;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NSubstitute;
+
+using Shouldly;
+
+namespace Encina.GuardTests.GraphQL;
+
+/// <summary>
+/// Guard tests for Encina.GraphQL covering constructor/method null guards and happy paths
+/// for <see cref="GraphQLEncinaBridge"/>, <see cref="ConnectionExtensions"/>,
+/// and <see cref="ServiceCollectionExtensions"/>.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class GraphQLGuardTests
+{
+    // ─── GraphQLEncinaBridge constructor guards ───
+
+    [Fact]
+    public void Bridge_NullEncina_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new GraphQLEncinaBridge(null!,
+                NullLogger<GraphQLEncinaBridge>.Instance,
+                Options.Create(new EncinaGraphQLOptions())));
+    }
+
+    [Fact]
+    public void Bridge_NullLogger_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        Should.Throw<ArgumentNullException>(() =>
+            new GraphQLEncinaBridge(encina, null!,
+                Options.Create(new EncinaGraphQLOptions())));
+    }
+
+    [Fact]
+    public void Bridge_NullOptions_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        Should.Throw<ArgumentNullException>(() =>
+            new GraphQLEncinaBridge(encina,
+                NullLogger<GraphQLEncinaBridge>.Instance, null!));
+    }
+
+    [Fact]
+    public void Bridge_ValidArgs_Constructs()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new GraphQLEncinaBridge(encina,
+            NullLogger<GraphQLEncinaBridge>.Instance,
+            Options.Create(new EncinaGraphQLOptions()));
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── GraphQLEncinaBridge method guards ───
+
+    [Fact]
+    public async Task Bridge_QueryAsync_NullQuery_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new GraphQLEncinaBridge(encina,
+            NullLogger<GraphQLEncinaBridge>.Instance,
+            Options.Create(new EncinaGraphQLOptions()));
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.QueryAsync<TestQuery, string>(null!));
+    }
+
+    [Fact]
+    public async Task Bridge_MutateAsync_NullMutation_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new GraphQLEncinaBridge(encina,
+            NullLogger<GraphQLEncinaBridge>.Instance,
+            Options.Create(new EncinaGraphQLOptions()));
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.MutateAsync<TestMutation, string>(null!));
+    }
+
+    [Fact]
+    public void Bridge_SubscribeAsync_NullSubscription_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new GraphQLEncinaBridge(encina,
+            NullLogger<GraphQLEncinaBridge>.Instance,
+            Options.Create(new EncinaGraphQLOptions()));
+
+        Should.Throw<ArgumentNullException>(() =>
+            sut.SubscribeAsync<TestSubscription, string>(null!));
+    }
+
+    public sealed record TestQuery : IRequest<string>;
+    public sealed record TestMutation : IRequest<string>;
+    public sealed class TestSubscription;
+
+    // ─── ConnectionExtensions.ToConnection(CursorPaginatedResult) guard ───
+
+    [Fact]
+    public void ToConnection_NullResult_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ConnectionExtensions.ToConnection<string>(null!));
+    }
+
+    // ─── ConnectionExtensions.Map guards ───
+
+    [Fact]
+    public void Map_NullConnection_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ConnectionExtensions.Map<string, int>(null!, s => s.Length));
+    }
+
+    [Fact]
+    public void Map_NullSelector_Throws()
+    {
+        var connection = new Connection<string>
+        {
+            Edges = [],
+            PageInfo = new RelayPageInfo(),
+            TotalCount = 0
+        };
+
+        Should.Throw<ArgumentNullException>(() =>
+            ConnectionExtensions.Map<string, int>(connection, null!));
+    }
+
+    [Fact]
+    public void Map_ValidArgs_MapsNodes()
+    {
+        var connection = new Connection<string>
+        {
+            Edges =
+            [
+                new Edge<string> { Node = "hello", Cursor = "c1" },
+                new Edge<string> { Node = "world", Cursor = "c2" }
+            ],
+            PageInfo = new RelayPageInfo
+            {
+                HasNextPage = false,
+                HasPreviousPage = false,
+                StartCursor = "c1",
+                EndCursor = "c2"
+            },
+            TotalCount = 2
+        };
+
+        var mapped = connection.Map(s => s.Length);
+
+        mapped.Edges.Count.ShouldBe(2);
+        mapped.Edges[0].Node.ShouldBe(5);
+        mapped.Edges[1].Node.ShouldBe(5);
+        mapped.TotalCount.ShouldBe(2);
+        mapped.PageInfo.StartCursor.ShouldBe("c1");
+    }
+
+    // ─── Connection<T> / Edge<T> / RelayPageInfo POCOs ───
+
+    [Fact]
+    public void Connection_Defaults()
+    {
+        var connection = new Connection<int>
+        {
+            Edges = [],
+            PageInfo = new RelayPageInfo(),
+            TotalCount = 0
+        };
+
+        connection.Nodes.ShouldBeEmpty();
+        connection.Edges.ShouldBeEmpty();
+        connection.TotalCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Edge_Defaults()
+    {
+        var edge = new Edge<string> { Node = "test", Cursor = "abc" };
+        edge.Node.ShouldBe("test");
+        edge.Cursor.ShouldBe("abc");
+    }
+
+    [Fact]
+    public void RelayPageInfo_Defaults()
+    {
+        var info = new RelayPageInfo();
+        info.HasNextPage.ShouldBeFalse();
+        info.HasPreviousPage.ShouldBeFalse();
+        info.StartCursor.ShouldBeNull();
+        info.EndCursor.ShouldBeNull();
+    }
+
+    // ─── ServiceCollectionExtensions ───
+
+    [Fact]
+    public void AddEncinaGraphQL_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaGraphQL());
+    }
+
+    [Fact]
+    public void AddEncinaGraphQL_ValidServices_Registers()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(Substitute.For<IEncina>());
+
+        var result = services.AddEncinaGraphQL();
+        result.ShouldNotBeNull();
+    }
+
+    // ─── EncinaGraphQLOptions ───
+
+    [Fact]
+    public void EncinaGraphQLOptions_Defaults()
+    {
+        var options = new EncinaGraphQLOptions();
+        options.ShouldNotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
Close the guard coverage gap for `Encina.GraphQL`. Unit was 75.47% but guard had 0 data.

### New guard tests
`GraphQLGuardTests.cs` (17 tests):
- **GraphQLEncinaBridge**: 3 constructor null guards + valid construction + 3 method null guards (QueryAsync, MutateAsync, SubscribeAsync)
- **ConnectionExtensions**: ToConnection null guard + Map null connection + Map null selector + Map happy-path (verifies node mapping + cursor preservation)
- **Connection<T> / Edge<T> / RelayPageInfo**: POCO defaults
- **ServiceCollectionExtensions**: null services guard + happy path
- **EncinaGraphQLOptions**: defaults

## Test plan
- [x] GuardTests GraphQL: **17** passed (was 0)
- [ ] CI Full measures coverage