### PR TITLE
fix(signalr): remove guard from manifest — zero guard clauses

### DIFF
--- a/.github/coverage-manifest/Encina.SignalR.json
+++ b/.github/coverage-manifest/Encina.SignalR.json
@@ -1,76 +1,69 @@
 {
   "package": "Encina.SignalR",
-  "generated": "2026-03-27T12:05:17Z",
+  "generated": "2026-04-13T00:00:00Z",
   "totalFiles": 9,
   "targets": {
-    "guard": 15,
     "unit": 55
   },
   "files": {
     "BroadcastToSignalRAttribute.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Attribute.cs",
+      "reason": "Attribute marker class — no guard clauses in the codebase (zero ThrowIfNull/ThrowIfNullOrWhiteSpace in the entire package)"
     },
     "GlobalSuppressions.cs": {
       "defaultTests": [],
       "defaultRule": "GlobalSuppressions.cs",
-      "reason": "Only [SuppressMessage] attributes"
+      "reason": "Only [SuppressMessage] attributes — no executable code"
     },
     "Health/SignalRHealthCheck.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
       "defaultRule": "*HealthCheck.cs",
-      "reason": "Health check with mockeable service dependencies"
+      "reason": "Health check — constructor has no null guards, code relies on DI framework guarantees"
     },
     "Log.cs": {
       "defaultTests": [],
       "defaultRule": "Log.cs",
-      "reason": "Source-generated [LoggerMessage] delegates, no logic"
+      "reason": "Source-generated [LoggerMessage] delegates — no guards, no invariants"
     },
     "MediatorHub.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Hub.cs",
+      "reason": "SignalR Hub — constructor has no null guards, depends on DI injection"
     },
     "ServiceCollectionExtensions.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
       "defaultRule": "*Extensions.cs",
-      "reason": "ServiceCollection extensions with conditional registration"
+      "reason": "DI registration extensions — no ThrowIfNull guards on parameters"
     },
     "SignalRNotificationBehavior.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
       "defaultRule": "*Behavior.cs",
-      "reason": "Behavioral component"
+      "reason": "Pipeline behavior — constructor has no null guards, depends on DI injection"
     },
     "SignalRNotificationBroadcaster.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Broadcaster.cs",
+      "reason": "Broadcaster service — constructor has no null guards, depends on DI injection"
     },
     "SignalROptions.cs": {
       "defaultTests": [
         "unit"
       ],
       "defaultRule": "*Options.cs",
-      "reason": "Configuration POCO with defaults and validation"
+      "reason": "Configuration POCO with defaults — no guard clauses"
     }
   }
 }


### PR DESCRIPTION
## Summary
Audit `Encina.SignalR` source code: the entire package has **zero** `ArgumentNullException.ThrowIfNull` or `ArgumentException.ThrowIfNullOrWhiteSpace` calls. The manifest incorrectly set a 15% guard target and marked 6 files with the guard flag, creating an impossible obligation (0 coverable guard lines × 15% = 0, but the flag itself creates a failing entry in the dashboard).

### Changes
- Remove `guard` from `targets` entirely
- Remove `guard` from all 6 files that had it
- Update reasons to document: constructors rely on DI framework guarantees with no explicit null guards

Unit coverage is already 85.58% (target 55%), so no additional tests needed.

## Test plan
- [x] Manifest-only change, no test files affected
- [ ] CI Full validates the dashboard no longer shows a guard gap