### PR TITLE
test(azure-servicebus): close guard coverage gap

### DIFF
--- a/tests/Encina.GuardTests/AzureServiceBus/AzureServiceBusGuardTests.cs
+++ b/tests/Encina.GuardTests/AzureServiceBus/AzureServiceBusGuardTests.cs
@@ -1,0 +1,151 @@
+using Azure.Messaging.ServiceBus;
+
+using Encina.AzureServiceBus;
+using Encina.AzureServiceBus.Health;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using NSubstitute;
+
+using Shouldly;
+
+namespace Encina.GuardTests.AzureServiceBus;
+
+/// <summary>
+/// Guard tests for Encina.AzureServiceBus covering constructor and method null guards.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class AzureServiceBusGuardTests
+{
+    private static ServiceBusClient CreateMockClient()
+    {
+        // ServiceBusClient can be constructed with a fake connection string for guard testing
+        // (it only validates format, doesn't connect)
+        return new ServiceBusClient("Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=dGVzdA==");
+    }
+
+    // ─── AzureServiceBusMessagePublisher constructor guards ───
+
+    [Fact]
+    public void Constructor_NullClient_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new AzureServiceBusMessagePublisher(null!,
+                NullLogger<AzureServiceBusMessagePublisher>.Instance,
+                Options.Create(new EncinaAzureServiceBusOptions())));
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws()
+    {
+        var client = CreateMockClient();
+        Should.Throw<ArgumentNullException>(() =>
+            new AzureServiceBusMessagePublisher(client, null!,
+                Options.Create(new EncinaAzureServiceBusOptions())));
+    }
+
+    [Fact]
+    public void Constructor_NullOptions_Throws()
+    {
+        var client = CreateMockClient();
+        Should.Throw<ArgumentNullException>(() =>
+            new AzureServiceBusMessagePublisher(client,
+                NullLogger<AzureServiceBusMessagePublisher>.Instance, null!));
+    }
+
+    [Fact]
+    public void Constructor_ValidArgs_Constructs()
+    {
+        var client = CreateMockClient();
+        var sut = new AzureServiceBusMessagePublisher(client,
+            NullLogger<AzureServiceBusMessagePublisher>.Instance,
+            Options.Create(new EncinaAzureServiceBusOptions()));
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── AzureServiceBusMessagePublisher method guards ───
+
+    [Fact]
+    public async Task SendToQueueAsync_NullMessage_Throws()
+    {
+        var client = CreateMockClient();
+        var sut = new AzureServiceBusMessagePublisher(client,
+            NullLogger<AzureServiceBusMessagePublisher>.Instance,
+            Options.Create(new EncinaAzureServiceBusOptions()));
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.SendToQueueAsync<object>(null!));
+    }
+
+    [Fact]
+    public async Task PublishToTopicAsync_NullMessage_Throws()
+    {
+        var client = CreateMockClient();
+        var sut = new AzureServiceBusMessagePublisher(client,
+            NullLogger<AzureServiceBusMessagePublisher>.Instance,
+            Options.Create(new EncinaAzureServiceBusOptions()));
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.PublishToTopicAsync<object>(null!));
+    }
+
+    // ─── ServiceCollectionExtensions guards ───
+
+    [Fact]
+    public void AddEncinaAzureServiceBus_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaAzureServiceBus(o =>
+                o.ConnectionString = "Endpoint=sb://x.servicebus.windows.net/;SharedAccessKeyName=y;SharedAccessKey=dA=="));
+    }
+
+    [Fact]
+    public void AddEncinaAzureServiceBus_NullConfigure_Throws()
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentNullException>(() =>
+            services.AddEncinaAzureServiceBus(null!));
+    }
+
+    [Fact]
+    public void AddEncinaAzureServiceBus_EmptyConnectionString_Throws()
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentException>(() =>
+            services.AddEncinaAzureServiceBus(_ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaAzureServiceBus_ValidConfig_Registers()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var result = services.AddEncinaAzureServiceBus(o =>
+            o.ConnectionString = "Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=dGVzdA==");
+
+        result.ShouldNotBeNull();
+    }
+
+    // ─── AzureServiceBusHealthCheck ───
+
+    [Fact]
+    public void AzureServiceBusHealthCheck_Constructs()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var sut = new AzureServiceBusHealthCheck(sp, null);
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── EncinaAzureServiceBusOptions ───
+
+    [Fact]
+    public void EncinaAzureServiceBusOptions_Defaults()
+    {
+        var options = new EncinaAzureServiceBusOptions();
+        options.ShouldNotBeNull();
+        options.ConnectionString.ShouldBe(string.Empty);
+    }
+}

--- a/tests/Encina.GuardTests/Encina.GuardTests.csproj
+++ b/tests/Encina.GuardTests/Encina.GuardTests.csproj
@@ -168,6 +168,7 @@
     <ProjectReference Include="..\..\src\Encina.Testing.WireMock\Encina.Testing.WireMock.csproj" />
     <ProjectReference Include="..\..\src\Encina.AmazonSQS\Encina.AmazonSQS.csproj" />
     <ProjectReference Include="..\..\src\Encina.GraphQL\Encina.GraphQL.csproj" />
+    <ProjectReference Include="..\..\src\Encina.AzureServiceBus\Encina.AzureServiceBus.csproj" />
     <ProjectReference Include="..\..\src\Encina.Testing.Pact\Encina.Testing.Pact.csproj" />
     <ProjectReference Include="..\Encina.TestInfrastructure\Encina.TestInfrastructure.csproj" />
 


### PR DESCRIPTION
## Summary
Close the guard coverage gap for `Encina.AzureServiceBus`. Unit was 97.01% but guard had 0 data.

### New guard tests
`AzureServiceBusGuardTests.cs` (12 tests):
- **AzureServiceBusMessagePublisher**: 3 constructor null guards + valid construction + 2 method null guards (SendToQueueAsync, PublishToTopicAsync)
- **ServiceCollectionExtensions**: null services + null configure + empty ConnectionString ArgumentException + valid config happy path
- **AzureServiceBusHealthCheck**: construction
- **EncinaAzureServiceBusOptions**: defaults

## Test plan
- [x] GuardTests AzureServiceBus: **12** passed (was 0)
- [ ] CI Full measures coverage