### PR TITLE
test(grpc): close guard coverage gap

### DIFF
--- a/tests/Encina.GuardTests/Encina.GuardTests.csproj
+++ b/tests/Encina.GuardTests/Encina.GuardTests.csproj
@@ -169,6 +169,7 @@
     <ProjectReference Include="..\..\src\Encina.AmazonSQS\Encina.AmazonSQS.csproj" />
     <ProjectReference Include="..\..\src\Encina.GraphQL\Encina.GraphQL.csproj" />
     <ProjectReference Include="..\..\src\Encina.AzureServiceBus\Encina.AzureServiceBus.csproj" />
+    <ProjectReference Include="..\..\src\Encina.gRPC\Encina.gRPC.csproj" />
     <ProjectReference Include="..\..\src\Encina.Testing.Pact\Encina.Testing.Pact.csproj" />
     <ProjectReference Include="..\Encina.TestInfrastructure\Encina.TestInfrastructure.csproj" />
 

--- a/tests/Encina.GuardTests/gRPC/GrpcGuardTests.cs
+++ b/tests/Encina.GuardTests/gRPC/GrpcGuardTests.cs
@@ -1,0 +1,215 @@
+using Encina.gRPC;
+using Encina.gRPC.Health;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using NSubstitute;
+
+using Shouldly;
+
+namespace Encina.GuardTests.gRPC;
+
+/// <summary>
+/// Guard tests for Encina.gRPC covering constructor and method null guards.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class GrpcGuardTests
+{
+    private static readonly ITypeResolver TypeResolver = Substitute.For<ITypeResolver>();
+
+    // ─── GrpcEncinaService constructor guards ───
+
+    [Fact]
+    public void GrpcEncinaService_NullEncina_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new GrpcEncinaService(null!,
+                NullLogger<GrpcEncinaService>.Instance,
+                TypeResolver,
+                Options.Create(new EncinaGrpcOptions())));
+    }
+
+    [Fact]
+    public void GrpcEncinaService_NullLogger_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        Should.Throw<ArgumentNullException>(() =>
+            new GrpcEncinaService(encina, null!, TypeResolver,
+                Options.Create(new EncinaGrpcOptions())));
+    }
+
+    [Fact]
+    public void GrpcEncinaService_NullTypeResolver_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        Should.Throw<ArgumentNullException>(() =>
+            new GrpcEncinaService(encina,
+                NullLogger<GrpcEncinaService>.Instance, null!,
+                Options.Create(new EncinaGrpcOptions())));
+    }
+
+    [Fact]
+    public void GrpcEncinaService_NullOptions_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        Should.Throw<ArgumentNullException>(() =>
+            new GrpcEncinaService(encina,
+                NullLogger<GrpcEncinaService>.Instance,
+                TypeResolver, null!));
+    }
+
+    [Fact]
+    public void GrpcEncinaService_ValidArgs_Constructs()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new GrpcEncinaService(encina,
+            NullLogger<GrpcEncinaService>.Instance,
+            TypeResolver,
+            Options.Create(new EncinaGrpcOptions()));
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── GrpcEncinaService method guards ───
+
+    [Fact]
+    public async Task SendAsync_NullRequestType_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new GrpcEncinaService(encina,
+            NullLogger<GrpcEncinaService>.Instance,
+            TypeResolver,
+            Options.Create(new EncinaGrpcOptions()));
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.SendAsync(null!, []));
+    }
+
+    [Fact]
+    public async Task SendAsync_NullRequestData_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new GrpcEncinaService(encina,
+            NullLogger<GrpcEncinaService>.Instance,
+            TypeResolver,
+            Options.Create(new EncinaGrpcOptions()));
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.SendAsync("SomeType", null!));
+    }
+
+    [Fact]
+    public async Task PublishAsync_NullNotificationType_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new GrpcEncinaService(encina,
+            NullLogger<GrpcEncinaService>.Instance,
+            TypeResolver,
+            Options.Create(new EncinaGrpcOptions()));
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.PublishAsync(null!, []));
+    }
+
+    [Fact]
+    public async Task PublishAsync_NullNotificationData_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new GrpcEncinaService(encina,
+            NullLogger<GrpcEncinaService>.Instance,
+            TypeResolver,
+            Options.Create(new EncinaGrpcOptions()));
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.PublishAsync("SomeType", null!));
+    }
+
+    // ─── CachingTypeResolver guards ───
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CachingTypeResolver_ResolveRequestType_InvalidName_Throws(string? name)
+    {
+        var sut = new CachingTypeResolver();
+        Should.Throw<ArgumentException>(() => sut.ResolveRequestType(name!));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CachingTypeResolver_ResolveNotificationType_InvalidName_Throws(string? name)
+    {
+        var sut = new CachingTypeResolver();
+        Should.Throw<ArgumentException>(() => sut.ResolveNotificationType(name!));
+    }
+
+    [Fact]
+    public void CachingTypeResolver_ResolveRequestType_UnknownType_ReturnsNull()
+    {
+        var sut = new CachingTypeResolver();
+        var result = sut.ResolveRequestType("NonExistent.Type.Name");
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void CachingTypeResolver_ResolveNotificationType_UnknownType_ReturnsNull()
+    {
+        var sut = new CachingTypeResolver();
+        var result = sut.ResolveNotificationType("NonExistent.Type.Name");
+        result.ShouldBeNull();
+    }
+
+    // ─── GrpcHealthCheck ───
+
+    [Fact]
+    public void GrpcHealthCheck_Constructs()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var sut = new GrpcHealthCheck(sp, null);
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── ServiceCollectionExtensions ───
+
+    [Fact]
+    public void AddEncinaGrpc_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaGrpc());
+    }
+
+    [Fact]
+    public void AddEncinaGrpc_ValidServices_Registers()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(Substitute.For<IEncina>());
+
+        var result = services.AddEncinaGrpc();
+        result.ShouldNotBeNull();
+    }
+
+    // ─── EncinaGrpcOptions ───
+
+    [Fact]
+    public void EncinaGrpcOptions_Defaults()
+    {
+        var options = new EncinaGrpcOptions();
+        options.ShouldNotBeNull();
+    }
+
+    // ─── GrpcSerializationException ───
+
+    [Fact]
+    public void GrpcSerializationException_WithJsonException()
+    {
+        var inner = new System.Text.Json.JsonException("bad json");
+        var ex = new GrpcSerializationException("outer", inner);
+        ex.Message.ShouldBe("outer");
+        ex.InnerException.ShouldBe(inner);
+    }
+}


### PR DESCRIPTION
## Summary
Close the guard coverage gap for `Encina.gRPC`. Unit was 75.13% but guard had 0 data.

### New guard tests
`GrpcGuardTests.cs` (22 tests):
- **GrpcEncinaService**: 4 constructor null guards + valid construction + 4 method null guards (`SendAsync` requestType/requestData, `PublishAsync` notificationType/notificationData)
- **CachingTypeResolver**: 6 ThrowIfNullOrWhiteSpace guards (3 per `Resolve*` method) + 2 unknown-type-returns-null tests
- **GrpcHealthCheck**: construction
- **ServiceCollectionExtensions**: null services guard + happy path
- **EncinaGrpcOptions**: defaults
- **GrpcSerializationException**: construction with JsonException inner

## Test plan
- [x] GuardTests gRPC: **22** passed (was 0)
- [ ] CI Full measures coverage