### PR TITLE
test(nats): close guard coverage gap

### DIFF
--- a/tests/Encina.GuardTests/Encina.GuardTests.csproj
+++ b/tests/Encina.GuardTests/Encina.GuardTests.csproj
@@ -171,6 +171,7 @@
     <ProjectReference Include="..\..\src\Encina.AzureServiceBus\Encina.AzureServiceBus.csproj" />
     <ProjectReference Include="..\..\src\Encina.gRPC\Encina.gRPC.csproj" />
     <ProjectReference Include="..\..\src\Encina.Kafka\Encina.Kafka.csproj" />
+    <ProjectReference Include="..\..\src\Encina.NATS\Encina.NATS.csproj" />
     <ProjectReference Include="..\..\src\Encina.Testing.Pact\Encina.Testing.Pact.csproj" />
     <ProjectReference Include="..\Encina.TestInfrastructure\Encina.TestInfrastructure.csproj" />
 

--- a/tests/Encina.GuardTests/NATS/NATSGuardTests.cs
+++ b/tests/Encina.GuardTests/NATS/NATSGuardTests.cs
@@ -1,0 +1,159 @@
+using Encina.NATS;
+using Encina.NATS.Health;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+
+using NSubstitute;
+
+using Shouldly;
+
+namespace Encina.GuardTests.NATS;
+
+/// <summary>
+/// Guard tests for Encina.NATS covering constructor and method null guards.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class NATSGuardTests
+{
+    private static readonly INatsConnection Connection = Substitute.For<INatsConnection>();
+
+    // ─── NATSMessagePublisher constructor guards ───
+
+    [Fact]
+    public void Constructor_NullConnection_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new NATSMessagePublisher(null!, null,
+                NullLogger<NATSMessagePublisher>.Instance,
+                Options.Create(new EncinaNATSOptions())));
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new NATSMessagePublisher(Connection, null, null!,
+                Options.Create(new EncinaNATSOptions())));
+    }
+
+    [Fact]
+    public void Constructor_NullOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new NATSMessagePublisher(Connection, null,
+                NullLogger<NATSMessagePublisher>.Instance, null!));
+    }
+
+    [Fact]
+    public void Constructor_ValidArgs_Constructs()
+    {
+        var sut = new NATSMessagePublisher(Connection, null,
+            NullLogger<NATSMessagePublisher>.Instance,
+            Options.Create(new EncinaNATSOptions()));
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Constructor_WithJetStream_Constructs()
+    {
+        var jetStream = Substitute.For<INatsJSContext>();
+        var sut = new NATSMessagePublisher(Connection, jetStream,
+            NullLogger<NATSMessagePublisher>.Instance,
+            Options.Create(new EncinaNATSOptions()));
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── NATSMessagePublisher method guards ───
+
+    [Fact]
+    public async Task PublishAsync_NullMessage_Throws()
+    {
+        var sut = new NATSMessagePublisher(Connection, null,
+            NullLogger<NATSMessagePublisher>.Instance,
+            Options.Create(new EncinaNATSOptions()));
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.PublishAsync<object>(null!));
+    }
+
+    [Fact]
+    public async Task RequestAsync_NullRequest_Throws()
+    {
+        var sut = new NATSMessagePublisher(Connection, null,
+            NullLogger<NATSMessagePublisher>.Instance,
+            Options.Create(new EncinaNATSOptions()));
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.RequestAsync<object, string>(null!));
+    }
+
+    [Fact]
+    public async Task JetStreamPublishAsync_NullMessage_Throws()
+    {
+        var sut = new NATSMessagePublisher(Connection, null,
+            NullLogger<NATSMessagePublisher>.Instance,
+            Options.Create(new EncinaNATSOptions()));
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.JetStreamPublishAsync<object>(null!));
+    }
+
+    // ─── NATSHealthCheck ───
+
+    [Fact]
+    public void NATSHealthCheck_Constructs()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var sut = new NATSHealthCheck(sp, null);
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── ServiceCollectionExtensions ───
+
+    [Fact]
+    public void AddEncinaNATS_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaNATS(_ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaNATS_ValidServices_Registers()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var result = services.AddEncinaNATS(o =>
+            o.Url = "nats://localhost:4222");
+        result.ShouldNotBeNull();
+    }
+
+    // ─── EncinaNATSOptions ───
+
+    [Fact]
+    public void EncinaNATSOptions_Defaults()
+    {
+        var options = new EncinaNATSOptions();
+        options.ShouldNotBeNull();
+    }
+
+    // ─── NATSPublishAck record ───
+
+    [Fact]
+    public void NATSPublishAck_PropertiesAssignable()
+    {
+        var ack = new NATSPublishAck(
+            Stream: "orders",
+            Sequence: 42,
+            Duplicate: false);
+
+        ack.Stream.ShouldBe("orders");
+        ack.Sequence.ShouldBe(42UL);
+        ack.Duplicate.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
Close the guard coverage gap for `Encina.NATS`. Unit was 74.73% but guard had 0 data.

### New guard tests
`NATSGuardTests.cs` (13 tests):
- **NATSMessagePublisher**: 3 constructor null guards + valid construction (with and without JetStream) + 3 method null guards (`PublishAsync`, `RequestAsync`, `JetStreamPublishAsync`)
- **NATSHealthCheck**: construction
- **ServiceCollectionExtensions**: null services guard + happy path
- **EncinaNATSOptions**: defaults
- **NATSPublishAck**: record assignment

## Test plan
- [x] GuardTests NATS: **13** passed (was 0)
- [ ] CI Full measures coverage