### PR TITLE
test(tenancy-aspnetcore): close guard coverage gap

### DIFF
--- a/tests/Encina.GuardTests/Encina.GuardTests.csproj
+++ b/tests/Encina.GuardTests/Encina.GuardTests.csproj
@@ -172,6 +172,7 @@
     <ProjectReference Include="..\..\src\Encina.gRPC\Encina.gRPC.csproj" />
     <ProjectReference Include="..\..\src\Encina.Kafka\Encina.Kafka.csproj" />
     <ProjectReference Include="..\..\src\Encina.NATS\Encina.NATS.csproj" />
+    <ProjectReference Include="..\..\src\Encina.Tenancy.AspNetCore\Encina.Tenancy.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Encina.Testing.Pact\Encina.Testing.Pact.csproj" />
     <ProjectReference Include="..\Encina.TestInfrastructure\Encina.TestInfrastructure.csproj" />
 

--- a/tests/Encina.GuardTests/Tenancy/AspNetCore/TenancyAspNetCoreGuardTests.cs
+++ b/tests/Encina.GuardTests/Tenancy/AspNetCore/TenancyAspNetCoreGuardTests.cs
@@ -1,0 +1,217 @@
+using Encina.Tenancy.AspNetCore;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using NSubstitute;
+
+using Shouldly;
+
+namespace Encina.GuardTests.Tenancy.AspNetCore;
+
+/// <summary>
+/// Guard tests for Encina.Tenancy.AspNetCore covering constructor and method null guards
+/// for resolvers, middleware, health checks, and service collection extensions.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class TenancyAspNetCoreGuardTests
+{
+    // ─── ClaimTenantResolver guards ───
+
+    [Fact]
+    public void ClaimTenantResolver_NullOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ClaimTenantResolver(null!));
+    }
+
+    [Fact]
+    public void ClaimTenantResolver_ValidOptions_Constructs()
+    {
+        var sut = new ClaimTenantResolver(Options.Create(new TenancyAspNetCoreOptions()));
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task ClaimTenantResolver_NullContext_Throws()
+    {
+        var sut = new ClaimTenantResolver(Options.Create(new TenancyAspNetCoreOptions()));
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.ResolveAsync(null!));
+    }
+
+    // ─── HeaderTenantResolver guards ───
+
+    [Fact]
+    public void HeaderTenantResolver_NullOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new HeaderTenantResolver(null!));
+    }
+
+    [Fact]
+    public void HeaderTenantResolver_ValidOptions_Constructs()
+    {
+        var sut = new HeaderTenantResolver(Options.Create(new TenancyAspNetCoreOptions()));
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task HeaderTenantResolver_NullContext_Throws()
+    {
+        var sut = new HeaderTenantResolver(Options.Create(new TenancyAspNetCoreOptions()));
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.ResolveAsync(null!));
+    }
+
+    // ─── RouteTenantResolver guards ───
+
+    [Fact]
+    public void RouteTenantResolver_NullOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new RouteTenantResolver(null!));
+    }
+
+    [Fact]
+    public void RouteTenantResolver_ValidOptions_Constructs()
+    {
+        var sut = new RouteTenantResolver(Options.Create(new TenancyAspNetCoreOptions()));
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task RouteTenantResolver_NullContext_Throws()
+    {
+        var sut = new RouteTenantResolver(Options.Create(new TenancyAspNetCoreOptions()));
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.ResolveAsync(null!));
+    }
+
+    // ─── SubdomainTenantResolver guards ───
+
+    [Fact]
+    public void SubdomainTenantResolver_NullOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new SubdomainTenantResolver(null!));
+    }
+
+    [Fact]
+    public void SubdomainTenantResolver_ValidOptions_Constructs()
+    {
+        var sut = new SubdomainTenantResolver(Options.Create(new TenancyAspNetCoreOptions()));
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task SubdomainTenantResolver_NullContext_Throws()
+    {
+        var sut = new SubdomainTenantResolver(Options.Create(new TenancyAspNetCoreOptions()));
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.ResolveAsync(null!));
+    }
+
+    // ─── ApplicationBuilderExtensions guard ───
+
+    [Fact]
+    public void UseTenantResolution_NullApp_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ApplicationBuilderExtensions.UseTenantResolution(null!));
+    }
+
+    // ─── HealthCheckBuilderExtensions guard ───
+
+    [Fact]
+    public void AddEncinaTenancy_NullBuilder_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            global::Encina.Tenancy.AspNetCore.Health.HealthCheckBuilderExtensions.AddEncinaTenancy(null!));
+    }
+
+    [Fact]
+    public void AddEncinaTenancy_ValidBuilder_Succeeds()
+    {
+        var services = new ServiceCollection();
+        var builder = services.AddHealthChecks();
+        Should.NotThrow(() =>
+            global::Encina.Tenancy.AspNetCore.Health.HealthCheckBuilderExtensions.AddEncinaTenancy(builder));
+    }
+
+    // ─── ServiceCollectionExtensions guards ───
+
+    [Fact]
+    public void AddEncinaTenancyAspNetCore_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaTenancyAspNetCore(_ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaTenancyAspNetCore_NullConfigure_Throws()
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentNullException>(() =>
+            services.AddEncinaTenancyAspNetCore(null!));
+    }
+
+    [Fact]
+    public void AddEncinaTenancyAspNetCore_ValidArgs_Registers()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+
+        var result = services.AddEncinaTenancyAspNetCore(_ => { });
+        result.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddTenantResolver_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddTenantResolver<HeaderTenantResolver>());
+    }
+
+    [Fact]
+    public void AddTenantResolverInstance_NullServices_Throws()
+    {
+        var resolver = Substitute.For<ITenantResolver>();
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddTenantResolver(resolver));
+    }
+
+    [Fact]
+    public void AddTenantResolverInstance_NullResolver_Throws()
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentNullException>(() =>
+            services.AddTenantResolver((ITenantResolver)null!));
+    }
+
+    [Fact]
+    public void AddTenantResolverFactory_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddTenantResolver(_ => Substitute.For<ITenantResolver>()));
+    }
+
+    [Fact]
+    public void AddTenantResolverFactory_NullFactory_Throws()
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentNullException>(() =>
+            services.AddTenantResolver((Func<IServiceProvider, ITenantResolver>)null!));
+    }
+
+    // ─── TenancyAspNetCoreOptions defaults ───
+
+    [Fact]
+    public void TenancyAspNetCoreOptions_Defaults()
+    {
+        var options = new TenancyAspNetCoreOptions();
+        options.ShouldNotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
Close the guard coverage gap for `Encina.Tenancy.AspNetCore`. Unit was 80.54% but guard had 0 data.

### New guard tests
`TenancyAspNetCoreGuardTests.cs` (24 tests):
- **4 tenant resolvers** (Claim/Header/Route/Subdomain): null options constructor + valid construction + null context ResolveAsync (12 tests)
- **ApplicationBuilderExtensions**: `UseTenantResolution` null app
- **HealthCheckBuilderExtensions**: `AddEncinaTenancy` null builder + valid
- **ServiceCollectionExtensions**: `AddEncinaTenancyAspNetCore` null services + null configure + valid; `AddTenantResolver<T>` null services; `AddTenantResolver` instance null services + null resolver; `AddTenantResolver` factory null services + null factory (8 tests)
- **TenancyAspNetCoreOptions**: defaults

`TenantResolverChain` is internal — excluded.

## Test plan
- [x] GuardTests: **24** passed (was 0)
- [ ] CI Full measures coverage