### PR TITLE
test(caching-valkey): close guard coverage gap

### DIFF
--- a/tests/Encina.GuardTests/Caching/Valkey/ValkeyGuardTests.cs
+++ b/tests/Encina.GuardTests/Caching/Valkey/ValkeyGuardTests.cs
@@ -1,0 +1,116 @@
+using Encina.Caching.Valkey;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NSubstitute;
+
+using Shouldly;
+
+using StackExchange.Redis;
+
+namespace Encina.GuardTests.Caching.Valkey;
+
+/// <summary>
+/// Guard tests for Encina.Caching.Valkey covering ThrowIfNull guards on all 4 overloads.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class ValkeyGuardTests
+{
+    // ─── Overload 1: (services, connectionString) ───
+
+    [Fact]
+    public void AddEncinaValkeyCache_String_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaValkeyCache("localhost:6379"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void AddEncinaValkeyCache_String_InvalidConnectionString_Throws(string? cs)
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentException>(() =>
+            services.AddEncinaValkeyCache(cs!));
+    }
+
+    // ─── Overload 2: (services, connectionString, cacheOptions, lockOptions) ───
+
+    [Fact]
+    public void AddEncinaValkeyCache_StringWithOptions_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaValkeyCache("localhost:6379", _ => { }, _ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaValkeyCache_StringWithOptions_NullCacheOptions_Throws()
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentNullException>(() =>
+            services.AddEncinaValkeyCache("localhost:6379", null!, _ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaValkeyCache_StringWithOptions_NullLockOptions_Throws()
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentNullException>(() =>
+            services.AddEncinaValkeyCache("localhost:6379", _ => { }, null!));
+    }
+
+    // ─── Overload 3: (services, connectionMultiplexer) ───
+
+    [Fact]
+    public void AddEncinaValkeyCache_Multiplexer_NullServices_Throws()
+    {
+        var mux = Substitute.For<IConnectionMultiplexer>();
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaValkeyCache(mux));
+    }
+
+    [Fact]
+    public void AddEncinaValkeyCache_Multiplexer_NullMultiplexer_Throws()
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentNullException>(() =>
+            services.AddEncinaValkeyCache((IConnectionMultiplexer)null!));
+    }
+
+    // ─── Overload 4: (services, connectionMultiplexer, cacheOptions, lockOptions) ───
+
+    [Fact]
+    public void AddEncinaValkeyCache_MultiplexerWithOptions_NullServices_Throws()
+    {
+        var mux = Substitute.For<IConnectionMultiplexer>();
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaValkeyCache(mux, _ => { }, _ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaValkeyCache_MultiplexerWithOptions_NullMultiplexer_Throws()
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentNullException>(() =>
+            services.AddEncinaValkeyCache((IConnectionMultiplexer)null!, _ => { }, _ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaValkeyCache_MultiplexerWithOptions_NullCacheOptions_Throws()
+    {
+        var mux = Substitute.For<IConnectionMultiplexer>();
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentNullException>(() =>
+            services.AddEncinaValkeyCache(mux, null!, _ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaValkeyCache_MultiplexerWithOptions_NullLockOptions_Throws()
+    {
+        var mux = Substitute.For<IConnectionMultiplexer>();
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentNullException>(() =>
+            services.AddEncinaValkeyCache(mux, _ => { }, null!));
+    }
+}

--- a/tests/Encina.GuardTests/Encina.GuardTests.csproj
+++ b/tests/Encina.GuardTests/Encina.GuardTests.csproj
@@ -176,6 +176,7 @@
     <ProjectReference Include="..\..\src\Encina.RabbitMQ\Encina.RabbitMQ.csproj" />
     <ProjectReference Include="..\..\src\Encina.Aspire.Testing\Encina.Aspire.Testing.csproj" />
     <ProjectReference Include="..\..\src\Encina.Caching.Garnet\Encina.Caching.Garnet.csproj" />
+    <ProjectReference Include="..\..\src\Encina.Caching.Valkey\Encina.Caching.Valkey.csproj" />
     <ProjectReference Include="..\..\src\Encina.Testing.Pact\Encina.Testing.Pact.csproj" />
     <ProjectReference Include="..\Encina.TestInfrastructure\Encina.TestInfrastructure.csproj" />
 


### PR DESCRIPTION
## Summary
Close the guard coverage gap for `Encina.Caching.Valkey`. Unit was 87.5% but guard had 0 data.

### New guard tests
`ValkeyGuardTests.cs` (12 tests) — same structure as Garnet (Redis-compatible wrapper), all 4 `AddEncinaValkeyCache` overloads:
- **Overload 1** (string): null services + null/empty connectionString
- **Overload 2** (string+options): null services + null cacheOptions + null lockOptions
- **Overload 3** (multiplexer): null services + null multiplexer
- **Overload 4** (multiplexer+options): null services + null multiplexer + null cacheOptions + null lockOptions

## Test plan
- [x] GuardTests Valkey: **12** passed (was 0)
- [ ] CI Full measures coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Se agregó un conjunto exhaustivo de pruebas unitarias para validar el comportamiento de gestión de argumentos en la configuración del caché Valkey. Las nuevas pruebas cubren múltiples escenarios y parámetros de inicialización, garantizando un manejo robusto y consistente de errores cuando se proporcionan valores inválidos, nulos o incompletos en los diferentes modos de configuración disponibles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->