### PR TITLE
test(hangfire): fix manifest and close guard gap

### DIFF
--- a/.github/coverage-manifest/Encina.Hangfire.json
+++ b/.github/coverage-manifest/Encina.Hangfire.json
@@ -1,11 +1,11 @@
 {
   "package": "Encina.Hangfire",
-  "generated": "2026-03-27T12:05:17Z",
+  "generated": "2026-04-13T00:00:00Z",
   "totalFiles": 7,
   "targets": {
     "guard": 15,
     "unit": 60,
-    "property": 28.0
+    "property": 28
   },
   "files": {
     "EncinaHangfireOptions.cs": {
@@ -13,41 +13,44 @@
         "unit"
       ],
       "defaultRule": "*Options.cs",
-      "reason": "Configuration POCO with defaults and validation"
+      "reason": "Configuration POCO with defaults — no guard clauses"
     },
     "GlobalSuppressions.cs": {
       "defaultTests": [],
       "defaultRule": "GlobalSuppressions.cs",
-      "reason": "Only [SuppressMessage] attributes"
+      "reason": "Only [SuppressMessage] attributes — no executable code"
     },
     "HangfireNotificationJobAdapter.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "guard",
+        "property"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Adapter.cs",
+      "reason": "Job adapter with constructor null guards and ExecuteAsync method guard. Property tests verify notification round-trip invariants."
     },
     "HangfireRequestJobAdapter.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "guard",
+        "property"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Adapter.cs",
+      "reason": "Job adapter with constructor null guards and ExecuteAsync method guard. Property tests verify request round-trip invariants."
     },
     "Health/HangfireHealthCheck.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "guard",
+        "property"
       ],
       "defaultRule": "*HealthCheck.cs",
-      "reason": "Health check with mockeable service dependencies"
+      "reason": "Health check with mockeable service dependencies. Property tests exercise health check invariants."
     },
     "Log.cs": {
       "defaultTests": [],
       "defaultRule": "Log.cs",
-      "reason": "Source-generated [LoggerMessage] delegates, no logic"
+      "reason": "Source-generated [LoggerMessage] delegates — no guards, no invariants"
     },
     "ServiceCollectionExtensions.cs": {
       "defaultTests": [
@@ -55,7 +58,7 @@
         "guard"
       ],
       "defaultRule": "*Extensions.cs",
-      "reason": "ServiceCollection extensions with conditional registration"
+      "reason": "ServiceCollection extensions — no ThrowIfNull guard on services parameter but exercises registration logic"
     }
   }
 }

--- a/tests/Encina.GuardTests/Hangfire/HangfireGuardTests.cs
+++ b/tests/Encina.GuardTests/Hangfire/HangfireGuardTests.cs
@@ -1,0 +1,119 @@
+using Encina.Hangfire;
+using Encina.Hangfire.Health;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NSubstitute;
+
+using Shouldly;
+
+namespace Encina.GuardTests.Hangfire;
+
+/// <summary>
+/// Guard tests for Encina.Hangfire covering constructor and method null guards.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class HangfireGuardTests
+{
+    // ─── HangfireNotificationJobAdapter constructor guards ───
+
+    [Fact]
+    public void NotificationAdapter_NullEncina_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new HangfireNotificationJobAdapter<TestNotification>(null!,
+                NullLogger<HangfireNotificationJobAdapter<TestNotification>>.Instance));
+    }
+
+    [Fact]
+    public void NotificationAdapter_NullLogger_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        Should.Throw<ArgumentNullException>(() =>
+            new HangfireNotificationJobAdapter<TestNotification>(encina, null!));
+    }
+
+    [Fact]
+    public void NotificationAdapter_ValidArgs_Constructs()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new HangfireNotificationJobAdapter<TestNotification>(encina,
+            NullLogger<HangfireNotificationJobAdapter<TestNotification>>.Instance);
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task NotificationAdapter_PublishAsync_NullNotification_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new HangfireNotificationJobAdapter<TestNotification>(encina,
+            NullLogger<HangfireNotificationJobAdapter<TestNotification>>.Instance);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.PublishAsync(null!));
+    }
+
+    // ─── HangfireRequestJobAdapter constructor guards ───
+
+    [Fact]
+    public void RequestAdapter_NullEncina_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new HangfireRequestJobAdapter<TestRequest, TestResponse>(null!,
+                NullLogger<HangfireRequestJobAdapter<TestRequest, TestResponse>>.Instance));
+    }
+
+    [Fact]
+    public void RequestAdapter_NullLogger_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        Should.Throw<ArgumentNullException>(() =>
+            new HangfireRequestJobAdapter<TestRequest, TestResponse>(encina, null!));
+    }
+
+    [Fact]
+    public void RequestAdapter_ValidArgs_Constructs()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new HangfireRequestJobAdapter<TestRequest, TestResponse>(encina,
+            NullLogger<HangfireRequestJobAdapter<TestRequest, TestResponse>>.Instance);
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task RequestAdapter_ExecuteAsync_NullRequest_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new HangfireRequestJobAdapter<TestRequest, TestResponse>(encina,
+            NullLogger<HangfireRequestJobAdapter<TestRequest, TestResponse>>.Instance);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.ExecuteAsync(null!));
+    }
+
+    // ─── HangfireHealthCheck ───
+
+    [Fact]
+    public void HangfireHealthCheck_Constructs()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var sut = new HangfireHealthCheck(sp, null);
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── EncinaHangfireOptions ───
+
+    [Fact]
+    public void EncinaHangfireOptions_Defaults()
+    {
+        var options = new EncinaHangfireOptions();
+        options.ShouldNotBeNull();
+    }
+
+    // ─── Test types ───
+
+    public sealed record TestNotification : INotification;
+    public sealed record TestRequest : IRequest<TestResponse>;
+    public sealed record TestResponse;
+}


### PR DESCRIPTION
## Summary
Fix the `Encina.Hangfire` manifest and close the guard coverage gap.

### Manifest fix
Added `property` flag to `HangfireNotificationJobAdapter.cs`, `HangfireRequestJobAdapter.cs`, and `HangfireHealthCheck.cs` — property tests already existed in `tests/Encina.PropertyTests/Web/Hangfire/` but weren't credited.

### New guard tests
`HangfireGuardTests.cs` (10 tests):
- **HangfireNotificationJobAdapter<T>**: 2 constructor null guards + valid construction + `PublishAsync` null notification
- **HangfireRequestJobAdapter<T1,T2>**: 2 constructor null guards + valid construction + `ExecuteAsync` null request
- **HangfireHealthCheck**: construction
- **EncinaHangfireOptions**: defaults

## Test plan
- [x] GuardTests Hangfire: **10** passed (was 0)
- [ ] CI Full measures coverage