### PR TITLE
test(quartz): fix manifest and close guard gap

### DIFF
--- a/.github/coverage-manifest/Encina.Quartz.json
+++ b/.github/coverage-manifest/Encina.Quartz.json
@@ -1,11 +1,11 @@
 {
   "package": "Encina.Quartz",
-  "generated": "2026-03-27T12:05:17Z",
+  "generated": "2026-04-13T00:00:00Z",
   "totalFiles": 9,
   "targets": {
     "guard": 15,
     "unit": 60,
-    "property": 26.0
+    "property": 26
   },
   "files": {
     "EncinaQuartzOptions.cs": {
@@ -13,61 +13,62 @@
         "unit"
       ],
       "defaultRule": "*Options.cs",
-      "reason": "Configuration POCO with defaults and validation"
+      "reason": "Configuration POCO with defaults — no guard clauses"
     },
     "GlobalSuppressions.cs": {
       "defaultTests": [],
       "defaultRule": "GlobalSuppressions.cs",
-      "reason": "Only [SuppressMessage] attributes"
+      "reason": "Only [SuppressMessage] attributes — no executable code"
     },
     "Health/QuartzHealthCheck.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "property"
       ],
       "defaultRule": "*HealthCheck.cs",
-      "reason": "Health check with mockeable service dependencies"
+      "reason": "Health check — no constructor null guards. Property tests exercise health check invariants."
     },
     "Log.cs": {
       "defaultTests": [],
       "defaultRule": "Log.cs",
-      "reason": "Source-generated [LoggerMessage] delegates, no logic"
+      "reason": "Source-generated [LoggerMessage] delegates — no guards, no invariants"
     },
     "Properties/AssemblyInfo.cs": {
       "defaultTests": [],
       "defaultRule": "AssemblyInfo.cs",
-      "reason": "Assembly metadata"
+      "reason": "Assembly metadata — no executable code"
     },
     "QuartzConstants.cs": {
       "defaultTests": [
         "unit"
       ],
       "defaultRule": "*Constants.cs",
-      "reason": "Static constants, verify values"
+      "reason": "Static constants — no guard clauses"
     },
     "QuartzNotificationJob.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "guard",
+        "property"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Job.cs",
+      "reason": "Job with constructor ThrowIfNull guards and Execute method guard. Property tests verify notification job invariants."
     },
     "QuartzRequestJob.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "guard",
+        "property"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "*Job.cs",
+      "reason": "Job with constructor ThrowIfNull guards and Execute method guard. Property tests verify request job invariants."
     },
     "ServiceCollectionExtensions.cs": {
       "defaultTests": [
-        "unit",
-        "guard"
+        "unit"
       ],
       "defaultRule": "*Extensions.cs",
-      "reason": "ServiceCollection extensions with conditional registration"
+      "reason": "DI registration extensions — no ThrowIfNull guards on parameters"
     }
   }
 }

--- a/tests/Encina.GuardTests/Quartz/QuartzGuardTests.cs
+++ b/tests/Encina.GuardTests/Quartz/QuartzGuardTests.cs
@@ -1,0 +1,107 @@
+using Encina.Quartz;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NSubstitute;
+
+using Quartz;
+
+using Shouldly;
+
+namespace Encina.GuardTests.Quartz;
+
+/// <summary>
+/// Guard tests for Encina.Quartz covering constructor and method null guards.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class QuartzGuardTests
+{
+    // ─── QuartzNotificationJob constructor guards ───
+
+    [Fact]
+    public void NotificationJob_NullEncina_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new QuartzNotificationJob<TestNotification>(null!,
+                NullLogger<QuartzNotificationJob<TestNotification>>.Instance));
+    }
+
+    [Fact]
+    public void NotificationJob_NullLogger_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        Should.Throw<ArgumentNullException>(() =>
+            new QuartzNotificationJob<TestNotification>(encina, null!));
+    }
+
+    [Fact]
+    public void NotificationJob_ValidArgs_Constructs()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new QuartzNotificationJob<TestNotification>(encina,
+            NullLogger<QuartzNotificationJob<TestNotification>>.Instance);
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task NotificationJob_Execute_NullContext_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new QuartzNotificationJob<TestNotification>(encina,
+            NullLogger<QuartzNotificationJob<TestNotification>>.Instance);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.Execute(null!));
+    }
+
+    // ─── QuartzRequestJob constructor guards ───
+
+    [Fact]
+    public void RequestJob_NullEncina_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new QuartzRequestJob<TestRequest, TestResponse>(null!,
+                NullLogger<QuartzRequestJob<TestRequest, TestResponse>>.Instance));
+    }
+
+    [Fact]
+    public void RequestJob_NullLogger_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        Should.Throw<ArgumentNullException>(() =>
+            new QuartzRequestJob<TestRequest, TestResponse>(encina, null!));
+    }
+
+    [Fact]
+    public void RequestJob_ValidArgs_Constructs()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new QuartzRequestJob<TestRequest, TestResponse>(encina,
+            NullLogger<QuartzRequestJob<TestRequest, TestResponse>>.Instance);
+        sut.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task RequestJob_Execute_NullContext_Throws()
+    {
+        var encina = Substitute.For<IEncina>();
+        var sut = new QuartzRequestJob<TestRequest, TestResponse>(encina,
+            NullLogger<QuartzRequestJob<TestRequest, TestResponse>>.Instance);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.Execute(null!));
+    }
+
+    // ─── EncinaQuartzOptions ───
+
+    [Fact]
+    public void EncinaQuartzOptions_Defaults()
+    {
+        var options = new EncinaQuartzOptions();
+        options.ShouldNotBeNull();
+    }
+
+    public sealed record TestNotification : INotification;
+    public sealed record TestRequest : IRequest<TestResponse>;
+    public sealed record TestResponse;
+}


### PR DESCRIPTION
## Summary
Fix the `Encina.Quartz` manifest and close the guard coverage gap.

### Manifest fixes
- Add `property` to `QuartzNotificationJob.cs`, `QuartzRequestJob.cs`, and `QuartzHealthCheck.cs` — property tests already exist in `tests/Encina.PropertyTests/Web/Quartz/`
- Remove `guard` from `ServiceCollectionExtensions.cs` and `QuartzHealthCheck.cs` — no ThrowIfNull guards

### New guard tests
`QuartzGuardTests.cs` (9 tests):
- **QuartzNotificationJob<T>**: 2 constructor null guards + valid construction + Execute null context
- **QuartzRequestJob<T1,T2>**: 2 constructor null guards + valid construction + Execute null context
- **EncinaQuartzOptions**: defaults

## Test plan
- [x] GuardTests Quartz: **9** passed (was 0)
- [ ] CI Full measures coverage