### PR TITLE
test(distributedlock-redis): fix manifest and close guard gap

### DIFF
--- a/.github/coverage-manifest/Encina.DistributedLock.Redis.json
+++ b/.github/coverage-manifest/Encina.DistributedLock.Redis.json
@@ -1,44 +1,46 @@
 {
   "package": "Encina.DistributedLock.Redis",
-  "generated": "2026-03-29T13:00:00Z",
+  "generated": "2026-04-13T00:00:00Z",
   "reviewed": true,
   "totalFiles": 5,
   "targets": {
     "guard": 20,
     "unit": 60,
-    "integration": 30.0
+    "integration": 30
   },
   "files": {
     "GlobalSuppressions.cs": {
       "defaultTests": [],
-      "reason": "Only [SuppressMessage] attributes, no logic"
+      "reason": "Only [SuppressMessage] attributes — no executable code"
     },
     "Health/RedisDistributedLockHealthCheck.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "guard",
+        "integration"
       ],
-      "reason": "Health check using IDatabase — mockeable via IConnectionMultiplexer"
+      "reason": "Health check with constructor ThrowIfNull guards. Integration tests exercise with real Redis via Testcontainers."
     },
     "RedisDistributedLockProvider.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "guard",
+        "integration"
       ],
-      "reason": "Lock provider using IConnectionMultiplexer.GetDatabase() — fully mockeable. Covers TryAcquire, Acquire, IsLocked, Extend, Release"
+      "reason": "Lock provider with constructor + method ThrowIfNull guards. Integration tests exercise TryAcquire/Release/IsLocked with real Redis via Testcontainers."
     },
     "RedisLockOptions.cs": {
       "defaultTests": [
         "unit"
       ],
-      "reason": "Configuration POCO — only needs defaults verification, no guard (no constructor params)"
+      "reason": "Configuration POCO with defaults — no guard clauses"
     },
     "ServiceCollectionExtensions.cs": {
       "defaultTests": [
         "unit",
         "guard"
       ],
-      "reason": "DI registration with options validation and health check toggle"
+      "reason": "DI registration with ThrowIfNull + ThrowIfNullOrEmpty guards and options validation"
     }
   }
 }

--- a/tests/Encina.GuardTests/Infrastructure/DistributedLock/RedisDistributedLockAdditionalGuardTests.cs
+++ b/tests/Encina.GuardTests/Infrastructure/DistributedLock/RedisDistributedLockAdditionalGuardTests.cs
@@ -1,0 +1,176 @@
+using Encina.DistributedLock.Redis;
+using Encina.DistributedLock.Redis.Health;
+using ProviderHealthCheckOptions = Encina.Messaging.Health.ProviderHealthCheckOptions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using NSubstitute;
+
+using Shouldly;
+
+using StackExchange.Redis;
+
+namespace Encina.GuardTests.Infrastructure.DistributedLock;
+
+/// <summary>
+/// Additional guard tests for Encina.DistributedLock.Redis covering
+/// ServiceCollectionExtensions, HealthCheck, and provider method guards.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class RedisDistributedLockAdditionalGuardTests
+{
+    private static readonly IConnectionMultiplexer Mux = Substitute.For<IConnectionMultiplexer>();
+
+    // ─── ServiceCollectionExtensions overload 1: (services, connectionString) ───
+
+    [Fact]
+    public void AddEncinaDistributedLockRedis_String_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaDistributedLockRedis("localhost:6379"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void AddEncinaDistributedLockRedis_String_InvalidConnectionString_Throws(string? cs)
+    {
+        Should.Throw<ArgumentException>(() =>
+            new ServiceCollection().AddEncinaDistributedLockRedis(cs!));
+    }
+
+    // ─── ServiceCollectionExtensions overload 2: (services, connectionString, configure) ───
+
+    [Fact]
+    public void AddEncinaDistributedLockRedis_StringWithConfigure_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaDistributedLockRedis("localhost:6379", _ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaDistributedLockRedis_StringWithConfigure_NullConfigure_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ServiceCollection().AddEncinaDistributedLockRedis("localhost:6379", null!));
+    }
+
+    // ─── ServiceCollectionExtensions overload 3: (services, multiplexer) ───
+
+    [Fact]
+    public void AddEncinaDistributedLockRedis_Multiplexer_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaDistributedLockRedis(Mux));
+    }
+
+    [Fact]
+    public void AddEncinaDistributedLockRedis_Multiplexer_NullMultiplexer_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ServiceCollection().AddEncinaDistributedLockRedis((IConnectionMultiplexer)null!));
+    }
+
+    // ─── ServiceCollectionExtensions overload 4: (services, multiplexer, configure) ───
+
+    [Fact]
+    public void AddEncinaDistributedLockRedis_MultiplexerWithConfigure_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaDistributedLockRedis(Mux, _ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaDistributedLockRedis_MultiplexerWithConfigure_NullMultiplexer_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ServiceCollection().AddEncinaDistributedLockRedis((IConnectionMultiplexer)null!, _ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaDistributedLockRedis_MultiplexerWithConfigure_NullConfigure_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ServiceCollection().AddEncinaDistributedLockRedis(Mux, null!));
+    }
+
+    // ─── RedisDistributedLockHealthCheck constructor guards ───
+
+    [Fact]
+    public void HealthCheck_NullConnection_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new RedisDistributedLockHealthCheck(null!, new ProviderHealthCheckOptions()));
+    }
+
+    [Fact]
+    public void HealthCheck_NullOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new RedisDistributedLockHealthCheck(Mux, (ProviderHealthCheckOptions)null!));
+    }
+
+    [Fact]
+    public void HealthCheck_ValidArgs_Constructs()
+    {
+        var sut = new RedisDistributedLockHealthCheck(Mux, new ProviderHealthCheckOptions());
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── RedisDistributedLockProvider method guards ───
+
+    [Fact]
+    public async Task TryAcquireAsync_NullResource_Throws()
+    {
+        var sut = new RedisDistributedLockProvider(Mux,
+            Options.Create(new RedisLockOptions()),
+            NullLogger<RedisDistributedLockProvider>.Instance);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.TryAcquireAsync(null!, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(100), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task AcquireAsync_NullResource_Throws()
+    {
+        var sut = new RedisDistributedLockProvider(Mux,
+            Options.Create(new RedisLockOptions()),
+            NullLogger<RedisDistributedLockProvider>.Instance);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.AcquireAsync(null!, TimeSpan.FromSeconds(10), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task IsLockedAsync_NullResource_Throws()
+    {
+        var sut = new RedisDistributedLockProvider(Mux,
+            Options.Create(new RedisLockOptions()),
+            NullLogger<RedisDistributedLockProvider>.Instance);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.IsLockedAsync(null!, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ExtendAsync_NullResource_Throws()
+    {
+        var sut = new RedisDistributedLockProvider(Mux,
+            Options.Create(new RedisLockOptions()),
+            NullLogger<RedisDistributedLockProvider>.Instance);
+
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.ExtendAsync(null!, TimeSpan.FromSeconds(10), CancellationToken.None));
+    }
+
+    // ─── RedisLockOptions defaults ───
+
+    [Fact]
+    public void RedisLockOptions_Defaults()
+    {
+        var options = new RedisLockOptions();
+        options.ShouldNotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
Fix the `Encina.DistributedLock.Redis` manifest and close the guard coverage gap.

### Manifest fix
Add `integration` flag to `RedisDistributedLockProvider.cs` and `RedisDistributedLockHealthCheck.cs` — Testcontainers-based integration tests exist but weren't credited.

### New guard tests
`RedisDistributedLockAdditionalGuardTests.cs` (18 tests):
- **ServiceCollectionExtensions**: 4 overloads × null guards (10 tests)
- **RedisDistributedLockHealthCheck**: null connection + null options + valid (3)
- **RedisDistributedLockProvider method guards**: TryAcquireAsync + AcquireAsync + IsLockedAsync + ExtendAsync with null resource (4)
- **RedisLockOptions**: defaults (1)

## Test plan
- [x] GuardTests: **21** passed (was 3)
- [ ] CI Full measures coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Se han añadido nuevas pruebas de validación de argumentos para Redis Distributed Lock, incluyendo validación de parámetros nulos en métodos de adquisición y construcción.
  * Se actualizó la cobertura de pruebas en el manifiesto de configuración.

* **Chores**
  * Se actualizaron metadatos internos de cobertura de pruebas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->