### PR TITLE
test(guardclauses): fix manifest and close guard gap

### DIFF
--- a/.github/coverage-manifest/Encina.GuardClauses.json
+++ b/.github/coverage-manifest/Encina.GuardClauses.json
@@ -1,25 +1,26 @@
 {
   "package": "Encina.GuardClauses",
-  "generated": "2026-03-27T12:05:17Z",
+  "generated": "2026-04-13T00:00:00Z",
   "totalFiles": 2,
   "targets": {
     "guard": 15,
     "unit": 60,
-    "property": 87.0
+    "property": 87
   },
   "files": {
     "GlobalSuppressions.cs": {
       "defaultTests": [],
       "defaultRule": "GlobalSuppressions.cs",
-      "reason": "Only [SuppressMessage] attributes"
+      "reason": "Only [SuppressMessage] attributes — no executable code"
     },
     "Guards.cs": {
       "defaultTests": [
         "unit",
-        "guard"
+        "guard",
+        "property"
       ],
-      "defaultRule": "*.cs",
-      "reason": "Default: assume testable with mocks"
+      "defaultRule": "Guards.cs",
+      "reason": "Static TryValidate* guard methods with validation invariants. Property tests verify invariants via FsCheck. Guard tests exercise null/empty/whitespace paths."
     }
   }
 }

--- a/tests/Encina.GuardTests/Validation/GuardClauses/GuardsGuardTests.cs
+++ b/tests/Encina.GuardTests/Validation/GuardClauses/GuardsGuardTests.cs
@@ -1,0 +1,279 @@
+using Encina.GuardClauses;
+
+using Shouldly;
+
+namespace Encina.GuardTests.Validation.GuardClauses;
+
+/// <summary>
+/// Guard tests for Encina.GuardClauses exercising each TryValidate* method
+/// with both valid and invalid inputs to generate line coverage.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class GuardsGuardTests
+{
+    // ─── TryValidateNotNull ───
+
+    [Fact]
+    public void TryValidateNotNull_Null_ReturnsFalse()
+    {
+        var result = Guards.TryValidateNotNull<string>(null, "param", out var error);
+        result.ShouldBeFalse();
+        error.Message.ShouldNotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void TryValidateNotNull_Valid_ReturnsTrue()
+    {
+        var result = Guards.TryValidateNotNull("value", "param", out _);
+        result.ShouldBeTrue();
+    }
+
+    // ─── TryValidateNotEmpty (string) ───
+
+    [Fact]
+    public void TryValidateNotEmpty_String_Null_ReturnsFalse()
+    {
+        var result = Guards.TryValidateNotEmpty((string?)null, "param", out var error);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateNotEmpty_String_Empty_ReturnsFalse()
+    {
+        var result = Guards.TryValidateNotEmpty("", "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateNotEmpty_String_Valid_ReturnsTrue()
+    {
+        var result = Guards.TryValidateNotEmpty("hello", "param", out _);
+        result.ShouldBeTrue();
+    }
+
+    // ─── TryValidateNotWhiteSpace ───
+
+    [Fact]
+    public void TryValidateNotWhiteSpace_Whitespace_ReturnsFalse()
+    {
+        var result = Guards.TryValidateNotWhiteSpace("   ", "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateNotWhiteSpace_Valid_ReturnsTrue()
+    {
+        var result = Guards.TryValidateNotWhiteSpace("text", "param", out _);
+        result.ShouldBeTrue();
+    }
+
+    // ─── TryValidateNotEmpty (collection) ───
+
+    [Fact]
+    public void TryValidateNotEmpty_Collection_Null_ReturnsFalse()
+    {
+        var result = Guards.TryValidateNotEmpty<int>(null, "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateNotEmpty_Collection_Empty_ReturnsFalse()
+    {
+        var result = Guards.TryValidateNotEmpty(Array.Empty<int>(), "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateNotEmpty_Collection_Valid_ReturnsTrue()
+    {
+        int[] items = [1, 2, 3];
+        var result = Guards.TryValidateNotEmpty(items, "param", out _);
+        result.ShouldBeTrue();
+    }
+
+    // ─── TryValidatePositive ───
+
+    [Fact]
+    public void TryValidatePositive_Negative_ReturnsFalse()
+    {
+        var result = Guards.TryValidatePositive(-1, "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidatePositive_Zero_ReturnsFalse()
+    {
+        var result = Guards.TryValidatePositive(0, "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidatePositive_Positive_ReturnsTrue()
+    {
+        var result = Guards.TryValidatePositive(42, "param", out _);
+        result.ShouldBeTrue();
+    }
+
+    // ─── TryValidateNegative ───
+
+    [Fact]
+    public void TryValidateNegative_Positive_ReturnsFalse()
+    {
+        var result = Guards.TryValidateNegative(1, "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateNegative_Negative_ReturnsTrue()
+    {
+        var result = Guards.TryValidateNegative(-5, "param", out _);
+        result.ShouldBeTrue();
+    }
+
+    // ─── TryValidateInRange ───
+
+    [Fact]
+    public void TryValidateInRange_BelowMin_ReturnsFalse()
+    {
+        var result = Guards.TryValidateInRange(0, "param", 1, 10, out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateInRange_AboveMax_ReturnsFalse()
+    {
+        var result = Guards.TryValidateInRange(11, "param", 1, 10, out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateInRange_InRange_ReturnsTrue()
+    {
+        var result = Guards.TryValidateInRange(5, "param", 1, 10, out _);
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryValidateInRange_AtMin_ReturnsTrue()
+    {
+        var result = Guards.TryValidateInRange(1, "param", 1, 10, out _);
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryValidateInRange_AtMax_ReturnsTrue()
+    {
+        var result = Guards.TryValidateInRange(10, "param", 1, 10, out _);
+        result.ShouldBeTrue();
+    }
+
+    // ─── TryValidateEmail ───
+
+    [Fact]
+    public void TryValidateEmail_Null_ReturnsFalse()
+    {
+        var result = Guards.TryValidateEmail(null, "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateEmail_Invalid_ReturnsFalse()
+    {
+        var result = Guards.TryValidateEmail("not-an-email", "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateEmail_Valid_ReturnsTrue()
+    {
+        var result = Guards.TryValidateEmail("user@example.com", "param", out _);
+        result.ShouldBeTrue();
+    }
+
+    // ─── TryValidateUrl ───
+
+    [Fact]
+    public void TryValidateUrl_Null_ReturnsFalse()
+    {
+        var result = Guards.TryValidateUrl(null, "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateUrl_Invalid_ReturnsFalse()
+    {
+        var result = Guards.TryValidateUrl("not-a-url", "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateUrl_Valid_ReturnsTrue()
+    {
+        var result = Guards.TryValidateUrl("https://example.com", "param", out _);
+        result.ShouldBeTrue();
+    }
+
+    // ─── TryValidateNotEmpty (Guid) ───
+
+    [Fact]
+    public void TryValidateNotEmpty_Guid_Empty_ReturnsFalse()
+    {
+        var result = Guards.TryValidateNotEmpty(Guid.Empty, "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidateNotEmpty_Guid_Valid_ReturnsTrue()
+    {
+        var result = Guards.TryValidateNotEmpty(Guid.NewGuid(), "param", out _);
+        result.ShouldBeTrue();
+    }
+
+    // ─── TryValidate (condition) ───
+
+    [Fact]
+    public void TryValidate_False_ReturnsFalse()
+    {
+        var result = Guards.TryValidate(false, "param", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidate_True_ReturnsTrue()
+    {
+        var result = Guards.TryValidate(true, "param", out _);
+        result.ShouldBeTrue();
+    }
+
+    // ─── TryValidatePattern ───
+
+    [Fact]
+    public void TryValidatePattern_Null_ReturnsFalse()
+    {
+        var result = Guards.TryValidatePattern(null, "param", @"^\d+$", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidatePattern_NoMatch_ReturnsFalse()
+    {
+        var result = Guards.TryValidatePattern("abc", "param", @"^\d+$", out _);
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryValidatePattern_Match_ReturnsTrue()
+    {
+        var result = Guards.TryValidatePattern("123", "param", @"^\d+$", out _);
+        result.ShouldBeTrue();
+    }
+
+    // ─── Custom message parameter ───
+
+    [Fact]
+    public void TryValidateNotNull_CustomMessage_IncludedInError()
+    {
+        Guards.TryValidateNotNull<string>(null, "param", out var error, "custom msg");
+        error.Message.ShouldContain("custom msg");
+    }
+}


### PR DESCRIPTION
## Summary
Fix the `Encina.GuardClauses` manifest and close the guard coverage gap.

### Manifest fix
Add `property` to `Guards.cs` — property tests exist in `tests/Encina.PropertyTests/Validation/GuardClauses/` but weren't credited.

### New guard tests
`GuardsGuardTests.cs` (34 tests) — every `TryValidate*` method exercised with valid + invalid inputs:
- TryValidateNotNull, NotEmpty (string/collection/Guid), NotWhiteSpace
- TryValidatePositive, Negative, InRange (boundary values)
- TryValidateEmail, Url, Pattern (null/invalid/valid)
- TryValidate (bool condition), custom message parameter

## Test plan
- [x] GuardTests GuardClauses: **34** passed (was 0)
- [ ] CI Full measures coverage