### PR TITLE
test(caching-redis): fix manifest and close guard gap

### DIFF
--- a/.github/coverage-manifest/Encina.Caching.Redis.json
+++ b/.github/coverage-manifest/Encina.Caching.Redis.json
@@ -1,57 +1,36 @@
 {
   "package": "Encina.Caching.Redis",
-  "generated": "2026-03-27T12:05:17Z",
+  "generated": "2026-04-13T00:00:00Z",
   "totalFiles": 6,
   "targets": {
     "guard": 20,
     "unit": 60,
-    "integration": 29.0
+    "integration": 29
   },
   "files": {
     "GlobalSuppressions.cs": {
       "defaultTests": [],
-      "defaultRule": "GlobalSuppressions.cs",
-      "reason": "Only [SuppressMessage] attributes"
+      "reason": "Only [SuppressMessage] attributes — no executable code"
     },
     "Health/RedisHealthCheck.cs": {
-      "defaultTests": [
-        "unit",
-        "guard"
-      ],
-      "defaultRule": "*HealthCheck.cs",
-      "reason": "Health check with mockeable service dependencies"
+      "defaultTests": ["unit", "integration"],
+      "reason": "Health check — no constructor ThrowIfNull guards. Integration tests exercise with real Redis."
     },
     "RedisCacheProvider.cs": {
-      "defaultTests": [
-        "unit",
-        "guard"
-      ],
-      "defaultRule": "*Provider.cs",
-      "reason": "Provider implementation with mockeable deps"
+      "defaultTests": ["unit", "guard", "integration"],
+      "reason": "Cache provider with 12 ThrowIfNull guards. Integration tests exercise with real Redis via Testcontainers."
     },
     "RedisDistributedLockProvider.cs": {
-      "defaultTests": [
-        "unit",
-        "guard"
-      ],
-      "defaultRule": "*Provider.cs",
-      "reason": "Provider implementation with mockeable deps"
+      "defaultTests": ["unit", "guard"],
+      "reason": "Lock provider with 7 ThrowIfNull guards"
     },
     "RedisPubSubProvider.cs": {
-      "defaultTests": [
-        "unit",
-        "guard"
-      ],
-      "defaultRule": "*Provider.cs",
-      "reason": "Provider implementation with mockeable deps"
+      "defaultTests": ["unit", "guard"],
+      "reason": "Pub/sub provider with 14 ThrowIfNull guards"
     },
     "ServiceCollectionExtensions.cs": {
-      "defaultTests": [
-        "unit",
-        "guard"
-      ],
-      "defaultRule": "*Extensions.cs",
-      "reason": "ServiceCollection extensions with conditional registration"
+      "defaultTests": ["unit", "guard"],
+      "reason": "DI registration with 12 ThrowIfNull/ThrowIfNullOrEmpty guards across 4 overloads"
     }
   }
 }

--- a/tests/Encina.GuardTests/Caching/Redis/RedisCachingGuardTests.cs
+++ b/tests/Encina.GuardTests/Caching/Redis/RedisCachingGuardTests.cs
@@ -1,0 +1,211 @@
+using Encina.Caching.Redis;
+using RedisDistributedLockProvider = Encina.Caching.Redis.RedisDistributedLockProvider;
+using RedisLockOptions = Encina.Caching.Redis.RedisLockOptions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using NSubstitute;
+
+using Shouldly;
+
+using StackExchange.Redis;
+
+namespace Encina.GuardTests.Caching.Redis;
+
+/// <summary>
+/// Guard tests for Encina.Caching.Redis covering constructor and method null guards
+/// for providers and ServiceCollectionExtensions.
+/// </summary>
+[Trait("Category", "Guard")]
+public sealed class RedisCachingGuardTests
+{
+    private static readonly IConnectionMultiplexer Mux = Substitute.For<IConnectionMultiplexer>();
+
+    // ─── RedisCacheProvider constructor guards ───
+
+    [Fact]
+    public void CacheProvider_NullConnection_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new RedisCacheProvider(null!,
+                Options.Create(new RedisCacheOptions()),
+                NullLogger<RedisCacheProvider>.Instance));
+    }
+
+    [Fact]
+    public void CacheProvider_NullOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new RedisCacheProvider(Mux, null!,
+                NullLogger<RedisCacheProvider>.Instance));
+    }
+
+    [Fact]
+    public void CacheProvider_NullLogger_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new RedisCacheProvider(Mux,
+                Options.Create(new RedisCacheOptions()), null!));
+    }
+
+    [Fact]
+    public void CacheProvider_ValidArgs_Constructs()
+    {
+        var sut = new RedisCacheProvider(Mux,
+            Options.Create(new RedisCacheOptions()),
+            NullLogger<RedisCacheProvider>.Instance);
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── RedisDistributedLockProvider constructor guards ───
+
+    [Fact]
+    public void LockProvider_NullConnection_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new RedisDistributedLockProvider(null!,
+                Options.Create(new RedisLockOptions()),
+                NullLogger<RedisDistributedLockProvider>.Instance));
+    }
+
+    [Fact]
+    public void LockProvider_NullOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new RedisDistributedLockProvider(Mux, null!,
+                NullLogger<RedisDistributedLockProvider>.Instance));
+    }
+
+    [Fact]
+    public void LockProvider_NullLogger_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new RedisDistributedLockProvider(Mux,
+                Options.Create(new RedisLockOptions()), null!));
+    }
+
+    [Fact]
+    public void LockProvider_ValidArgs_Constructs()
+    {
+        var sut = new RedisDistributedLockProvider(Mux,
+            Options.Create(new RedisLockOptions()),
+            NullLogger<RedisDistributedLockProvider>.Instance);
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── RedisPubSubProvider constructor guards ───
+
+    [Fact]
+    public void PubSubProvider_NullConnection_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new RedisPubSubProvider(null!,
+                NullLogger<RedisPubSubProvider>.Instance));
+    }
+
+    [Fact]
+    public void PubSubProvider_NullLogger_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new RedisPubSubProvider(Mux, null!));
+    }
+
+    [Fact]
+    public void PubSubProvider_ValidArgs_Constructs()
+    {
+        var sut = new RedisPubSubProvider(Mux,
+            NullLogger<RedisPubSubProvider>.Instance);
+        sut.ShouldNotBeNull();
+    }
+
+    // ─── ServiceCollectionExtensions overload 1: (services, connectionString) ───
+
+    [Fact]
+    public void AddEncinaRedisCache_String_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaRedisCache("localhost:6379"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void AddEncinaRedisCache_String_InvalidConnectionString_Throws(string? cs)
+    {
+        Should.Throw<ArgumentException>(() =>
+            new ServiceCollection().AddEncinaRedisCache(cs!));
+    }
+
+    // ─── ServiceCollectionExtensions overload 2: (services, connectionString, configure, configureLock) ───
+
+    [Fact]
+    public void AddEncinaRedisCache_StringWithOptions_NullCacheOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ServiceCollection().AddEncinaRedisCache("localhost:6379", null!, _ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaRedisCache_StringWithOptions_NullLockOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ServiceCollection().AddEncinaRedisCache("localhost:6379", _ => { }, null!));
+    }
+
+    // ─── ServiceCollectionExtensions overload 3: (services, multiplexer) ───
+
+    [Fact]
+    public void AddEncinaRedisCache_Multiplexer_NullServices_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            ((IServiceCollection)null!).AddEncinaRedisCache(Mux));
+    }
+
+    [Fact]
+    public void AddEncinaRedisCache_Multiplexer_NullMultiplexer_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ServiceCollection().AddEncinaRedisCache((IConnectionMultiplexer)null!));
+    }
+
+    // ─── ServiceCollectionExtensions overload 4: (services, multiplexer, configure, configureLock) ───
+
+    [Fact]
+    public void AddEncinaRedisCache_MultiplexerWithOptions_NullMultiplexer_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ServiceCollection().AddEncinaRedisCache((IConnectionMultiplexer)null!, _ => { }, _ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaRedisCache_MultiplexerWithOptions_NullCacheOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ServiceCollection().AddEncinaRedisCache(Mux, null!, _ => { }));
+    }
+
+    [Fact]
+    public void AddEncinaRedisCache_MultiplexerWithOptions_NullLockOptions_Throws()
+    {
+        Should.Throw<ArgumentNullException>(() =>
+            new ServiceCollection().AddEncinaRedisCache(Mux, _ => { }, null!));
+    }
+
+    // ─── Options defaults ───
+
+    [Fact]
+    public void RedisCacheOptions_Defaults()
+    {
+        var options = new RedisCacheOptions();
+        options.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void RedisLockOptions_Defaults()
+    {
+        var options = new RedisLockOptions();
+        options.ShouldNotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
Fix the `Encina.Caching.Redis` manifest and close the guard coverage gap.

### Manifest fixes
- Remove `guard` from `RedisHealthCheck.cs` (0 ThrowIfNull guards)
- Add `integration` to `RedisCacheProvider.cs` and `RedisHealthCheck.cs` — Testcontainers-based integration tests exist but weren't credited

### New guard tests
`RedisCachingGuardTests.cs` (23 tests):
- **RedisCacheProvider**: 3 constructor null guards + valid
- **RedisDistributedLockProvider**: 3 constructor null guards + valid
- **RedisPubSubProvider**: 2 constructor null guards + valid
- **ServiceCollectionExtensions**: 4 overloads × null guards (9 tests)
- Options defaults (2)

## Test plan
- [x] GuardTests: **23** passed (was 0)
- [ ] CI Full measures coverage