### PR TITLE
fix(testing-architecture): address PR #966 review findings

### DIFF
--- a/.github/scripts/mut-docs-render.cs
+++ b/.github/scripts/mut-docs-render.cs
@@ -101,7 +101,7 @@ foreach (var file in mdFiles)
         segment = tableMarkerRegex.Replace(segment, match =>
         {
             var pattern = match.Groups["pattern"].Value;
-            var table = GenerateTable(pattern, indexJson, ref warnings);
+            var table = GenerateTable(pattern, indexJson, file, ref warnings);
             tablesGenerated++;
             return $"{match.Groups[1].Value}\n{table}\n{match.Groups[2].Value}";
         });
@@ -207,7 +207,7 @@ if (warnings > 0)
 return 0;
 
 
-static string GenerateTable(string pattern, JsonObject index, ref int warnings)
+static string GenerateTable(string pattern, JsonObject index, string sourceFile, ref int warnings)
 {
     var regex = GlobToRegex(pattern);
     var matches = new List<(string Id, JsonObject Entry)>();
@@ -252,9 +252,18 @@ static string GenerateTable(string pattern, JsonObject index, ref int warnings)
         sb.AppendLine($"| {fileCell} | {score:F2}% | {killed} | {survived} | {noCov} | {total} | {lastRunShort} |");
     }
 
+    var methodologyRel = ComputeRelativePath(sourceFile, "docs/testing/mutation-measurement-methodology.md");
     sb.AppendLine();
-    sb.AppendLine($"*{matches.Count} file(s) matched `{pattern}`. Data from [mutations dashboard](https://dlrivada.github.io/Encina/mutations/). See [mutation-measurement-methodology.md](../testing/mutation-measurement-methodology.md).*");
+    sb.AppendLine($"*{matches.Count} file(s) matched `{pattern}`. Data from [mutations dashboard](https://dlrivada.github.io/Encina/mutations/). See [mutation-measurement-methodology.md]({methodologyRel}).*");
     return sb.ToString();
+}
+
+static string ComputeRelativePath(string sourceFile, string targetPath)
+{
+    var sourceDir = Path.GetDirectoryName(Path.GetFullPath(sourceFile)) ?? ".";
+    var targetFull = Path.GetFullPath(targetPath);
+    var rel = Path.GetRelativePath(sourceDir, targetFull);
+    return rel.Replace('\\', '/');
 }
 
 static string LookupInlineValue(string id, string field, JsonObject index, ref int warnings)

--- a/docs/en/guides/MUTATION_TESTING.md
+++ b/docs/en/guides/MUTATION_TESTING.md
@@ -28,7 +28,7 @@ The current accumulated snapshot:
 | <a id="mutref-mut-Encina-Sharding-Migrations-Strategies-RollingUpdateStrategy-cs"></a>[`Sharding/Migrations/Strategies/RollingUpdateStrategy.cs`](https://dlrivada.github.io/Encina/mutations/#pkg-Encina) | 0.00% | 0 | 15 | 0 | 15 | 2026-04-14 |
 | <a id="mutref-mut-Encina-Sharding-Migrations-Strategies-SequentialMigrationStrategy-cs"></a>[`Sharding/Migrations/Strategies/SequentialMigrationStrategy.cs`](https://dlrivada.github.io/Encina/mutations/#pkg-Encina) | 21.43% | 3 | 11 | 0 | 14 | 2026-04-14 |
 
-*4 file(s) matched `mut:Encina/Sharding/Migrations/Strategies/*`. Data from [mutations dashboard](https://dlrivada.github.io/Encina/mutations/). See [mutation-measurement-methodology.md](../testing/mutation-measurement-methodology.md).*
+*4 file(s) matched `mut:Encina/Sharding/Migrations/Strategies/*`. Data from [mutations dashboard](https://dlrivada.github.io/Encina/mutations/). See [mutation-measurement-methodology.md](../../testing/mutation-measurement-methodology.md).*
 
 <!-- /mutref-table -->
 
@@ -40,7 +40,7 @@ The current accumulated snapshot:
 | <a id="mutref-mut-Encina-Sharding-Health-ShardReplicaHealthCheck-cs"></a>[`Sharding/Health/ShardReplicaHealthCheck.cs`](https://dlrivada.github.io/Encina/mutations/#pkg-Encina) | 0.00% | 0 | 29 | 0 | 29 | 2026-04-14 |
 | <a id="mutref-mut-Encina-Sharding-Health-ShardedHealthSummary-cs"></a>[`Sharding/Health/ShardedHealthSummary.cs`](https://dlrivada.github.io/Encina/mutations/#pkg-Encina) | 0.00% | 0 | 12 | 0 | 12 | 2026-04-14 |
 
-*3 file(s) matched `mut:Encina/Sharding/Health/*`. Data from [mutations dashboard](https://dlrivada.github.io/Encina/mutations/). See [mutation-measurement-methodology.md](../testing/mutation-measurement-methodology.md).*
+*3 file(s) matched `mut:Encina/Sharding/Health/*`. Data from [mutations dashboard](https://dlrivada.github.io/Encina/mutations/). See [mutation-measurement-methodology.md](../../testing/mutation-measurement-methodology.md).*
 
 <!-- /mutref-table -->
 
@@ -216,6 +216,6 @@ The dashboard's per-file score is the reliable signal: anything in the `mut:Enci
 - [Mutation measurement methodology](../../testing/mutation-measurement-methodology.md) — formulas, accumulation, citation system
 - [Coverage measurement methodology](../../testing/coverage-measurement-methodology.md) — the obligations model and how coverage and mutation differ
 - [Performance measurement methodology](../../testing/performance-measurement-methodology.md) — the docref system this one is modelled after
-- [Stryker.NET docs](https://stryker-mutator.io/docs/stryker-net/)
+- [Stryker.NET docs](https://stryker-mutator.io/docs/stryker-net/introduction/)
 - [Issue #957](https://github.com/dlrivada/Encina/issues/957) — workflow stabilization (closed)
 - [Issue #962](https://github.com/dlrivada/Encina/issues/962) — scope widening + cited-by (closed)

--- a/docs/testing/mutation-measurement-methodology.md
+++ b/docs/testing/mutation-measurement-methodology.md
@@ -67,7 +67,7 @@ The two folders measured during the workflow stabilization (smoke test + Health)
 | <a id="mutref-mut-Encina-Sharding-Migrations-Strategies-RollingUpdateStrategy-cs"></a>[`Sharding/Migrations/Strategies/RollingUpdateStrategy.cs`](https://dlrivada.github.io/Encina/mutations/#pkg-Encina) | 0.00% | 0 | 15 | 0 | 15 | 2026-04-14 |
 | <a id="mutref-mut-Encina-Sharding-Migrations-Strategies-SequentialMigrationStrategy-cs"></a>[`Sharding/Migrations/Strategies/SequentialMigrationStrategy.cs`](https://dlrivada.github.io/Encina/mutations/#pkg-Encina) | 21.43% | 3 | 11 | 0 | 14 | 2026-04-14 |
 
-*4 file(s) matched `mut:Encina/Sharding/Migrations/Strategies/*`. Data from [mutations dashboard](https://dlrivada.github.io/Encina/mutations/). See [mutation-measurement-methodology.md](../testing/mutation-measurement-methodology.md).*
+*4 file(s) matched `mut:Encina/Sharding/Migrations/Strategies/*`. Data from [mutations dashboard](https://dlrivada.github.io/Encina/mutations/). See [mutation-measurement-methodology.md](mutation-measurement-methodology.md).*
 
 <!-- /mutref-table -->
 
@@ -79,7 +79,7 @@ The two folders measured during the workflow stabilization (smoke test + Health)
 | <a id="mutref-mut-Encina-Sharding-Health-ShardReplicaHealthCheck-cs"></a>[`Sharding/Health/ShardReplicaHealthCheck.cs`](https://dlrivada.github.io/Encina/mutations/#pkg-Encina) | 0.00% | 0 | 29 | 0 | 29 | 2026-04-14 |
 | <a id="mutref-mut-Encina-Sharding-Health-ShardedHealthSummary-cs"></a>[`Sharding/Health/ShardedHealthSummary.cs`](https://dlrivada.github.io/Encina/mutations/#pkg-Encina) | 0.00% | 0 | 12 | 0 | 12 | 2026-04-14 |
 
-*3 file(s) matched `mut:Encina/Sharding/Health/*`. Data from [mutations dashboard](https://dlrivada.github.io/Encina/mutations/). See [mutation-measurement-methodology.md](../testing/mutation-measurement-methodology.md).*
+*3 file(s) matched `mut:Encina/Sharding/Health/*`. Data from [mutations dashboard](https://dlrivada.github.io/Encina/mutations/). See [mutation-measurement-methodology.md](mutation-measurement-methodology.md).*
 
 <!-- /mutref-table -->
 

--- a/tests/Encina.GuardTests/Testing/Architecture/ArchitectureGuardTests.cs
+++ b/tests/Encina.GuardTests/Testing/Architecture/ArchitectureGuardTests.cs
@@ -287,6 +287,7 @@ public sealed class ArchitectureGuardTests
     {
         var result = EventIdUniquenessRule.ExtractEventIds([]);
         result.ShouldNotBeNull();
+        result.ShouldBeEmpty();
     }
 
     [Fact]
@@ -308,6 +309,7 @@ public sealed class ArchitectureGuardTests
     {
         var result = EventIdUniquenessRule.AssertEventIdsAreGloballyUnique([]);
         result.ShouldNotBeNull();
+        result.ShouldBeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Addresses Copilot review findings from merged PR #966.

### Changes

- `ExtractEventIds_EmptyAssemblies_ReturnsEmpty`: added `ShouldBeEmpty()` — was only asserting `ShouldNotBeNull()` which doesn't validate the "returns empty" claim
- `AssertEventIdsAreGloballyUnique_EmptyAssemblies_ReturnsEmpty`: same fix

### Related

- Addresses review comments from Copilot on #966
- Part of retroactive review audit for PRs merged without waiting for reviewers

### Test plan

- [x] `dotnet test --filter ArchitectureGuardTests` — 53 tests pass
- [ ] CI guard tests pass
- [ ] CodeRabbit review
- [ ] Copilot review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Pruebas**
  * Se actualizaron casos de prueba para mejorar la validación de resultados vacíos en las reglas de unicidad de eventos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->