### PR TITLE
fix(testing-wiremock): address PR #967 review findings

### DIFF
--- a/tests/Encina.GuardTests/Testing/WireMock/WireMockGuardTests.cs
+++ b/tests/Encina.GuardTests/Testing/WireMock/WireMockGuardTests.cs
@@ -69,8 +69,10 @@ public sealed class WireMockGuardTests : IAsyncLifetime
     [Theory]
     [InlineData(null, "/path")]
     [InlineData("", "/path")]
+    [InlineData("   ", "/path")]
     [InlineData("GET", null)]
     [InlineData("GET", "")]
+    [InlineData("GET", "   ")]
     public void StubSequence_InvalidMethodOrPath_Throws(string? method, string? path)
     {
         Should.Throw<ArgumentException>(() =>
@@ -136,6 +138,7 @@ public sealed class WireMockGuardTests : IAsyncLifetime
     [Theory]
     [InlineData(null)]
     [InlineData("")]
+    [InlineData("   ")]
     public void SetupOutboxWebhook_InvalidPath_Throws(string? path)
     {
         Should.Throw<ArgumentException>(() =>
@@ -152,6 +155,7 @@ public sealed class WireMockGuardTests : IAsyncLifetime
     [Theory]
     [InlineData(null)]
     [InlineData("")]
+    [InlineData("   ")]
     public void SetupWebhookFailure_InvalidPath_Throws(string? path)
     {
         Should.Throw<ArgumentException>(() =>
@@ -168,6 +172,7 @@ public sealed class WireMockGuardTests : IAsyncLifetime
     [Theory]
     [InlineData(null)]
     [InlineData("")]
+    [InlineData("   ")]
     public void SetupWebhookTimeout_InvalidPath_Throws(string? path)
     {
         Should.Throw<ArgumentException>(() =>
@@ -184,6 +189,7 @@ public sealed class WireMockGuardTests : IAsyncLifetime
     [Theory]
     [InlineData(null)]
     [InlineData("")]
+    [InlineData("   ")]
     public void VerifyWebhookReceived_InvalidPath_Throws(string? path)
     {
         Should.Throw<ArgumentException>(() =>
@@ -197,6 +203,16 @@ public sealed class WireMockGuardTests : IAsyncLifetime
             WebhookTestingExtensions.VerifyNoWebhooksReceived(null!, "/webhook"));
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void VerifyNoWebhooksReceived_InvalidPath_Throws(string? path)
+    {
+        Should.Throw<ArgumentException>(() =>
+            WebhookTestingExtensions.VerifyNoWebhooksReceived(_fixture, path!));
+    }
+
     [Fact]
     public void GetReceivedWebhooks_NullFixture_Throws()
     {
@@ -204,11 +220,31 @@ public sealed class WireMockGuardTests : IAsyncLifetime
             WebhookTestingExtensions.GetReceivedWebhooks(null!, "/webhook"));
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetReceivedWebhooks_InvalidPath_Throws(string? path)
+    {
+        Should.Throw<ArgumentException>(() =>
+            WebhookTestingExtensions.GetReceivedWebhooks(_fixture, path!));
+    }
+
     [Fact]
     public void GetReceivedWebhookBodies_NullFixture_Throws()
     {
         Should.Throw<ArgumentNullException>(() =>
             WebhookTestingExtensions.GetReceivedWebhookBodies<object>(null!, "/webhook"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetReceivedWebhookBodies_InvalidPath_Throws(string? path)
+    {
+        Should.Throw<ArgumentException>(() =>
+            WebhookTestingExtensions.GetReceivedWebhookBodies<object>(_fixture, path!));
     }
 
     // ─── ReceivedRequest record ───


### PR DESCRIPTION
## Summary

Addresses Copilot review findings from merged PR #967.

### Changes

1. **Missing whitespace cases**: Added `"   "` InlineData to 5 theories (SetupOutboxWebhook, SetupWebhookFailure, SetupWebhookTimeout, VerifyWebhookReceived, StubSequence) — all source methods use `ThrowIfNullOrWhiteSpace`
2. **Missing path guard tests**: Added invalid-path theories for VerifyNoWebhooksReceived, GetReceivedWebhooks, GetReceivedWebhookBodies (only had null-fixture tests, missing path validation)

### Related

- Addresses review comments from Copilot on #967
- Part of retroactive review audit for PRs merged without waiting for reviewers

### Test plan

- [x] `dotnet test --filter WireMockGuardTests` — 56 tests pass
- [ ] CI guard tests pass
- [ ] CodeRabbit review
- [ ] Copilot review