### PR TITLE
fix(amazon-sqs): address PR #968 review findings

### DIFF
--- a/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
+++ b/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
@@ -97,7 +97,7 @@ public sealed class AmazonSQSGuardTests
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
         await Should.ThrowAsync<ArgumentNullException>(
-            async () => await sut.SendBatchAsync<object>(null!));
+            () => sut.SendBatchAsync<object>(null!).AsTask());
     }
 
     [Fact]

--- a/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
+++ b/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
@@ -87,7 +87,7 @@ public sealed class AmazonSQSGuardTests
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
         await Should.ThrowAsync<ArgumentNullException>(
-            async () => await sut.PublishToTopicAsync<object>(null!));
+            () => sut.PublishToTopicAsync<object>(null!).AsTask());
     }
 
     [Fact]

--- a/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
+++ b/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
@@ -117,7 +117,7 @@ public sealed class AmazonSQSGuardTests
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.SendToFifoQueueAsync(new { Id = 1 }, null!));
+            () => sut.SendToFifoQueueAsync(new { Id = 1 }, null!).AsTask());
     }
 
     // ─── AmazonSQSHealthCheck ───

--- a/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
+++ b/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
@@ -150,7 +150,26 @@ public sealed class AmazonSQSGuardTests
         var result = services.AddEncinaAmazonSQS(_ => { });
 
         result.ShouldNotBeNull();
-        services.ShouldContain(sd => sd.ServiceType == typeof(IAmazonSQSMessagePublisher));
+
+        ServiceDescriptor? publisherDescriptor = null;
+        foreach (var service in services)
+        {
+            if (service.ServiceType == typeof(IAmazonSQSMessagePublisher))
+            {
+                publisherDescriptor = service;
+                break;
+            }
+        }
+
+        publisherDescriptor.ShouldNotBeNull();
+        (publisherDescriptor.ImplementationType is not null
+            || publisherDescriptor.ImplementationFactory is not null
+            || publisherDescriptor.ImplementationInstance is not null).ShouldBeTrue();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var publisher = serviceProvider.GetRequiredService<IAmazonSQSMessagePublisher>();
+
+        publisher.ShouldNotBeNull();
     }
 
     // ─── EncinaAmazonSQSOptions defaults ───

--- a/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
+++ b/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
@@ -179,7 +179,6 @@ public sealed class AmazonSQSGuardTests
     {
         var options = new EncinaAmazonSQSOptions();
 
-        options.ShouldNotBeNull();
         options.Region.ShouldBe("us-east-1");
         options.DefaultQueueUrl.ShouldBeNull();
         options.DefaultTopicArn.ShouldBeNull();

--- a/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
+++ b/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
@@ -76,8 +76,8 @@ public sealed class AmazonSQSGuardTests
         var sut = new AmazonSQSMessagePublisher(SqsClient, SnsClient,
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.SendToQueueAsync<object>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.SendToQueueAsync<object>(null!));
     }
 
     [Fact]
@@ -86,8 +86,8 @@ public sealed class AmazonSQSGuardTests
         var sut = new AmazonSQSMessagePublisher(SqsClient, SnsClient,
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.PublishToTopicAsync<object>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.PublishToTopicAsync<object>(null!));
     }
 
     [Fact]
@@ -96,8 +96,8 @@ public sealed class AmazonSQSGuardTests
         var sut = new AmazonSQSMessagePublisher(SqsClient, SnsClient,
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.SendBatchAsync<object>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.SendBatchAsync<object>(null!));
     }
 
     [Fact]
@@ -106,8 +106,8 @@ public sealed class AmazonSQSGuardTests
         var sut = new AmazonSQSMessagePublisher(SqsClient, SnsClient,
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.SendToFifoQueueAsync<object>(null!, "group-1"));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.SendToFifoQueueAsync<object>(null!, "group-1"));
     }
 
     [Fact]
@@ -116,8 +116,8 @@ public sealed class AmazonSQSGuardTests
         var sut = new AmazonSQSMessagePublisher(SqsClient, SnsClient,
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.SendToFifoQueueAsync(new { Id = 1 }, null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.SendToFifoQueueAsync(new { Id = 1 }, null!));
     }
 
     // ─── AmazonSQSHealthCheck ───
@@ -140,7 +140,7 @@ public sealed class AmazonSQSGuardTests
     }
 
     [Fact]
-    public void AddEncinaAmazonSQS_ValidServices_Registers()
+    public void AddEncinaAmazonSQS_ValidServices_RegistersExpectedServices()
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -148,7 +148,9 @@ public sealed class AmazonSQSGuardTests
         services.AddSingleton(SnsClient);
 
         var result = services.AddEncinaAmazonSQS(_ => { });
+
         result.ShouldNotBeNull();
+        services.ShouldContain(sd => sd.ServiceType == typeof(IAmazonSQSMessagePublisher));
     }
 
     // ─── EncinaAmazonSQSOptions defaults ───
@@ -157,6 +159,15 @@ public sealed class AmazonSQSGuardTests
     public void EncinaAmazonSQSOptions_Defaults()
     {
         var options = new EncinaAmazonSQSOptions();
+
         options.ShouldNotBeNull();
+        options.Region.ShouldBe("us-east-1");
+        options.DefaultQueueUrl.ShouldBeNull();
+        options.DefaultTopicArn.ShouldBeNull();
+        options.UseFifoQueues.ShouldBeFalse();
+        options.MaxNumberOfMessages.ShouldBe(10);
+        options.VisibilityTimeoutSeconds.ShouldBe(30);
+        options.WaitTimeSeconds.ShouldBe(20);
+        options.UseContentBasedDeduplication.ShouldBeFalse();
     }
 }

--- a/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
+++ b/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
@@ -107,7 +107,7 @@ public sealed class AmazonSQSGuardTests
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.SendToFifoQueueAsync<object>(null!, "group-1"));
+            () => sut.SendToFifoQueueAsync<object>(null!, "group-1").AsTask());
     }
 
     [Fact]

--- a/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
+++ b/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
@@ -77,7 +77,7 @@ public sealed class AmazonSQSGuardTests
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
         await Should.ThrowAsync<ArgumentNullException>(
-            async () => await sut.SendToQueueAsync<object>(null!));
+            () => sut.SendToQueueAsync<object>(null!).AsTask());
     }
 
     [Fact]

--- a/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
+++ b/tests/Encina.GuardTests/AmazonSQS/AmazonSQSGuardTests.cs
@@ -77,7 +77,7 @@ public sealed class AmazonSQSGuardTests
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.SendToQueueAsync<object>(null!));
+            async () => await sut.SendToQueueAsync<object>(null!));
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public sealed class AmazonSQSGuardTests
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.PublishToTopicAsync<object>(null!));
+            async () => await sut.PublishToTopicAsync<object>(null!));
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public sealed class AmazonSQSGuardTests
             NullLogger<AmazonSQSMessagePublisher>.Instance, Options);
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.SendBatchAsync<object>(null!));
+            async () => await sut.SendBatchAsync<object>(null!));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Addresses Copilot review findings from merged PR #968.

### Changes

1. **Stronger registration test**: `AddEncinaAmazonSQS_ValidServices_Registers` now asserts `IAmazonSQSMessagePublisher` is registered (not just non-null return)
2. **Meaningful defaults test**: `EncinaAmazonSQSOptions_Defaults` now verifies all 8 default property values (Region, MaxNumberOfMessages, etc.)
3. **Simplified async**: Removed redundant `async () => await` wrappers in 5 ThrowAsync assertions

### Not addressed (by design)

- `AmazonSQSHealthCheck_Constructs` with null options: constructor accepts `ProviderHealthCheckOptions?` (nullable) — null is valid by design

### Related

- Addresses review comments from Copilot on #968
- Part of retroactive review audit for PRs merged without waiting for reviewers

### Test plan

- [x] `dotnet test --filter AmazonSQSGuardTests` — 14 tests pass
- [ ] CI guard tests pass
- [ ] CodeRabbit review
- [ ] Copilot review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de la versión

* **Tests**
  * Ajustadas aserciones para comprobar excepciones en escenarios asincrónicos y evitar falsos positivos.
  * Renombrada y ampliada la prueba de registro de servicios para verificar que la interfaz esperada está registrada y puede resolverse correctamente.
  * Expandidas las comprobaciones de valores por defecto para varias opciones de configuración.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->