### PR TITLE
fix(graphql): address PR #969 review findings

### DIFF
--- a/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
+++ b/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
@@ -68,7 +68,7 @@ public sealed class GraphQLGuardTests
             Options.Create(new EncinaGraphQLOptions()));
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.QueryAsync<TestQuery, string>(null!));
+            () => sut.QueryAsync<TestQuery, string>(null!).AsTask());
     }
 
     [Fact]

--- a/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
+++ b/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
@@ -80,7 +80,7 @@ public sealed class GraphQLGuardTests
             Options.Create(new EncinaGraphQLOptions()));
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.MutateAsync<TestMutation, string>(null!));
+            () => sut.MutateAsync<TestMutation, string>(null!).AsTask());
     }
 
     [Fact]

--- a/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
+++ b/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
@@ -67,8 +67,8 @@ public sealed class GraphQLGuardTests
             NullLogger<GraphQLEncinaBridge>.Instance,
             Options.Create(new EncinaGraphQLOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.QueryAsync<TestQuery, string>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.QueryAsync<TestQuery, string>(null!));
     }
 
     [Fact]
@@ -79,8 +79,8 @@ public sealed class GraphQLGuardTests
             NullLogger<GraphQLEncinaBridge>.Instance,
             Options.Create(new EncinaGraphQLOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.MutateAsync<TestMutation, string>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.MutateAsync<TestMutation, string>(null!));
     }
 
     [Fact]
@@ -155,9 +155,12 @@ public sealed class GraphQLGuardTests
 
         mapped.Edges.Count.ShouldBe(2);
         mapped.Edges[0].Node.ShouldBe(5);
+        mapped.Edges[0].Cursor.ShouldBe("c1");
         mapped.Edges[1].Node.ShouldBe(5);
+        mapped.Edges[1].Cursor.ShouldBe("c2");
         mapped.TotalCount.ShouldBe(2);
         mapped.PageInfo.StartCursor.ShouldBe("c1");
+        mapped.PageInfo.EndCursor.ShouldBe("c2");
     }
 
     // ─── Connection<T> / Edge<T> / RelayPageInfo POCOs ───
@@ -205,14 +208,16 @@ public sealed class GraphQLGuardTests
     }
 
     [Fact]
-    public void AddEncinaGraphQL_ValidServices_Registers()
+    public void AddEncinaGraphQL_ValidServices_RegistersExpectedServices()
     {
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton(Substitute.For<IEncina>());
 
         var result = services.AddEncinaGraphQL();
+
         result.ShouldNotBeNull();
+        services.ShouldContain(sd => sd.ServiceType == typeof(IGraphQLEncinaBridge));
     }
 
     // ─── EncinaGraphQLOptions ───
@@ -221,6 +226,15 @@ public sealed class GraphQLGuardTests
     public void EncinaGraphQLOptions_Defaults()
     {
         var options = new EncinaGraphQLOptions();
+
         options.ShouldNotBeNull();
+        options.Path.ShouldBe("/graphql");
+        options.EnableGraphQLIDE.ShouldBeTrue();
+        options.EnableIntrospection.ShouldBeTrue();
+        options.IncludeExceptionDetails.ShouldBeFalse();
+        options.MaxExecutionDepth.ShouldBe(15);
+        options.ExecutionTimeout.ShouldBe(TimeSpan.FromSeconds(30));
+        options.EnableSubscriptions.ShouldBeTrue();
+        options.EnablePersistedQueries.ShouldBeFalse();
     }
 }

--- a/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
+++ b/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
@@ -208,7 +208,7 @@ public sealed class GraphQLGuardTests
     }
 
     [Fact]
-    public void AddEncinaGraphQL_ValidServices_RegistersExpectedServices()
+    public void AddEncinaGraphQL_ValidServices_RegistersBridge()
     {
         var services = new ServiceCollection();
         services.AddLogging();

--- a/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
+++ b/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
@@ -215,9 +215,16 @@ public sealed class GraphQLGuardTests
         services.AddSingleton(Substitute.For<IEncina>());
 
         var result = services.AddEncinaGraphQL();
+        var bridgeRegistrations = services.Where(sd => sd.ServiceType == typeof(IGraphQLEncinaBridge)).ToList();
 
         result.ShouldNotBeNull();
-        services.ShouldContain(sd => sd.ServiceType == typeof(IGraphQLEncinaBridge));
+        bridgeRegistrations.Count.ShouldBe(1);
+
+        var bridgeRegistration = bridgeRegistrations[0];
+        bridgeRegistration.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+        bridgeRegistration.ImplementationType.ShouldBe(typeof(GraphQLEncinaBridge));
+        bridgeRegistration.ImplementationFactory.ShouldBeNull();
+        bridgeRegistration.ImplementationInstance.ShouldBeNull();
     }
 
     // ─── EncinaGraphQLOptions ───

--- a/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
+++ b/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
@@ -221,7 +221,7 @@ public sealed class GraphQLGuardTests
         bridgeRegistrations.Count.ShouldBe(1);
 
         var bridgeRegistration = bridgeRegistrations[0];
-        bridgeRegistration.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+        bridgeRegistration.Lifetime.ShouldBe(ServiceLifetime.Scoped);
         bridgeRegistration.ImplementationType.ShouldBe(typeof(GraphQLEncinaBridge));
         bridgeRegistration.ImplementationFactory.ShouldBeNull();
         bridgeRegistration.ImplementationInstance.ShouldBeNull();

--- a/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
+++ b/tests/Encina.GuardTests/GraphQL/GraphQLGuardTests.cs
@@ -234,7 +234,6 @@ public sealed class GraphQLGuardTests
     {
         var options = new EncinaGraphQLOptions();
 
-        options.ShouldNotBeNull();
         options.Path.ShouldBe("/graphql");
         options.EnableGraphQLIDE.ShouldBeTrue();
         options.EnableIntrospection.ShouldBeTrue();


### PR DESCRIPTION
## Summary

Addresses Copilot review findings from merged PR #969.

### Changes

1. **Defaults test**: `EncinaGraphQLOptions_Defaults` now asserts all 8 default property values (Path, EnableGraphQLIDE, MaxExecutionDepth, etc.)
2. **Registration test**: `AddEncinaGraphQL_ValidServices_Registers` now asserts `IGraphQLEncinaBridge` is registered
3. **Cursor preservation**: `Map_ValidArgs_MapsNodes` now asserts `EndCursor` and per-edge `Cursor` values are preserved
4. **Simplified async**: Removed redundant `async/await` wrappers in QueryAsync/MutateAsync ThrowAsync assertions

### Not addressed (by design)

- `SubscribeAsync` sync vs async guard: method returns `IAsyncEnumerable`, guard throws synchronously before iteration — `Should.Throw` is correct

### Related

- Addresses review comments from Copilot on #969
- Part of retroactive review audit

### Test plan

- [x] `dotnet test --filter GraphQLGuardTests` — 17 tests pass
- [ ] CI guard tests pass