### PR TITLE
fix(kafka): address PR #973 review findings

### DIFF
--- a/tests/Encina.GuardTests/Kafka/KafkaGuardTests.cs
+++ b/tests/Encina.GuardTests/Kafka/KafkaGuardTests.cs
@@ -89,7 +89,7 @@ public sealed class KafkaGuardTests
             Options.Create(new EncinaKafkaOptions()));
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.ProduceWithHeadersAsync<object>(null!, new Dictionary<string, byte[]>()));
+            () => sut.ProduceWithHeadersAsync<object>(null!, new Dictionary<string, byte[]>()).AsTask());
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public sealed class KafkaGuardTests
             Options.Create(new EncinaKafkaOptions()));
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.ProduceWithHeadersAsync(new { Id = 1 }, (IDictionary<string, byte[]>)null!));
+            () => sut.ProduceWithHeadersAsync(new { Id = 1 }, (IDictionary<string, byte[]>)null!).AsTask());
     }
 
     // ─── KafkaHealthCheck ───

--- a/tests/Encina.GuardTests/Kafka/KafkaGuardTests.cs
+++ b/tests/Encina.GuardTests/Kafka/KafkaGuardTests.cs
@@ -132,7 +132,20 @@ public sealed class KafkaGuardTests
             o.BootstrapServers = "localhost:9092");
 
         result.ShouldNotBeNull();
-        services.ShouldContain(sd => sd.ServiceType == typeof(IKafkaMessagePublisher));
+
+        ServiceDescriptor? publisherRegistration = null;
+        foreach (var service in services)
+        {
+            if (service.ServiceType == typeof(IKafkaMessagePublisher))
+            {
+                publisherRegistration = service;
+                break;
+            }
+        }
+
+        publisherRegistration.ShouldNotBeNull();
+        publisherRegistration!.ImplementationType.ShouldBe(typeof(KafkaMessagePublisher));
+        publisherRegistration.Lifetime.ShouldBe(ServiceLifetime.Singleton);
     }
 
     // ─── EncinaKafkaOptions ───

--- a/tests/Encina.GuardTests/Kafka/KafkaGuardTests.cs
+++ b/tests/Encina.GuardTests/Kafka/KafkaGuardTests.cs
@@ -67,7 +67,7 @@ public sealed class KafkaGuardTests
             Options.Create(new EncinaKafkaOptions()));
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.ProduceAsync<object>(null!));
+            async () => await sut.ProduceAsync<object>(null!));
     }
 
     [Fact]

--- a/tests/Encina.GuardTests/Kafka/KafkaGuardTests.cs
+++ b/tests/Encina.GuardTests/Kafka/KafkaGuardTests.cs
@@ -145,7 +145,7 @@ public sealed class KafkaGuardTests
 
         publisherRegistration.ShouldNotBeNull();
         publisherRegistration!.ImplementationType.ShouldBe(typeof(KafkaMessagePublisher));
-        publisherRegistration.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+        publisherRegistration.Lifetime.ShouldBe(ServiceLifetime.Scoped);
     }
 
     // ─── EncinaKafkaOptions ───

--- a/tests/Encina.GuardTests/Kafka/KafkaGuardTests.cs
+++ b/tests/Encina.GuardTests/Kafka/KafkaGuardTests.cs
@@ -78,7 +78,7 @@ public sealed class KafkaGuardTests
             Options.Create(new EncinaKafkaOptions()));
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.ProduceBatchAsync<object>(null!));
+            () => sut.ProduceBatchAsync<object>(null!).AsTask());
     }
 
     [Fact]

--- a/tests/Encina.GuardTests/Kafka/KafkaGuardTests.cs
+++ b/tests/Encina.GuardTests/Kafka/KafkaGuardTests.cs
@@ -66,8 +66,8 @@ public sealed class KafkaGuardTests
             NullLogger<KafkaMessagePublisher>.Instance,
             Options.Create(new EncinaKafkaOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.ProduceAsync<object>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.ProduceAsync<object>(null!));
     }
 
     [Fact]
@@ -77,8 +77,8 @@ public sealed class KafkaGuardTests
             NullLogger<KafkaMessagePublisher>.Instance,
             Options.Create(new EncinaKafkaOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.ProduceBatchAsync<object>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.ProduceBatchAsync<object>(null!));
     }
 
     [Fact]
@@ -88,8 +88,8 @@ public sealed class KafkaGuardTests
             NullLogger<KafkaMessagePublisher>.Instance,
             Options.Create(new EncinaKafkaOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.ProduceWithHeadersAsync<object>(null!, new Dictionary<string, byte[]>()));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.ProduceWithHeadersAsync<object>(null!, new Dictionary<string, byte[]>()));
     }
 
     [Fact]
@@ -99,8 +99,8 @@ public sealed class KafkaGuardTests
             NullLogger<KafkaMessagePublisher>.Instance,
             Options.Create(new EncinaKafkaOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.ProduceWithHeadersAsync(new { Id = 1 }, (IDictionary<string, byte[]>)null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.ProduceWithHeadersAsync(new { Id = 1 }, (IDictionary<string, byte[]>)null!));
     }
 
     // ─── KafkaHealthCheck ───
@@ -108,7 +108,7 @@ public sealed class KafkaGuardTests
     [Fact]
     public void KafkaHealthCheck_Constructs()
     {
-        var sp = new ServiceCollection().BuildServiceProvider();
+        using var sp = new ServiceCollection().BuildServiceProvider();
         var sut = new KafkaHealthCheck(sp, null);
         sut.ShouldNotBeNull();
     }
@@ -123,14 +123,16 @@ public sealed class KafkaGuardTests
     }
 
     [Fact]
-    public void AddEncinaKafka_ValidServices_Registers()
+    public void AddEncinaKafka_ValidServices_RegistersExpectedServices()
     {
         var services = new ServiceCollection();
         services.AddLogging();
 
         var result = services.AddEncinaKafka(o =>
             o.BootstrapServers = "localhost:9092");
+
         result.ShouldNotBeNull();
+        services.ShouldContain(sd => sd.ServiceType == typeof(IKafkaMessagePublisher));
     }
 
     // ─── EncinaKafkaOptions ───
@@ -139,7 +141,17 @@ public sealed class KafkaGuardTests
     public void EncinaKafkaOptions_Defaults()
     {
         var options = new EncinaKafkaOptions();
+
         options.ShouldNotBeNull();
+        options.BootstrapServers.ShouldBe("localhost:9092");
+        options.GroupId.ShouldBe("encina-consumer");
+        options.DefaultCommandTopic.ShouldBe("encina-commands");
+        options.DefaultEventTopic.ShouldBe("encina-events");
+        options.AutoOffsetReset.ShouldBe("earliest");
+        options.EnableAutoCommit.ShouldBeFalse();
+        options.Acks.ShouldBe("all");
+        options.EnableIdempotence.ShouldBeTrue();
+        options.MessageTimeoutMs.ShouldBe(30000);
     }
 
     // ─── KafkaDeliveryResult record ───


### PR DESCRIPTION
## Summary

Addresses Copilot review findings from merged PR #973.

### Changes

1. **Defaults test**: asserts all 9 default property values for `EncinaKafkaOptions`
2. **Registration test**: verifies `IKafkaMessagePublisher` is registered
3. **Dispose**: added `using` to `ServiceProvider` in health check test
4. **Simplified async**: removed redundant `async/await` in 4 ThrowAsync assertions

### Related

- Addresses review comments from Copilot on #973

### Test plan

- [x] `dotnet test --filter KafkaGuardTests` — 13 tests pass
- [ ] CI guard tests pass