### PR TITLE
fix(nats): address PR #974 review findings

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -52,6 +52,7 @@ exclude = [
     # Sites that frequently timeout or block CI
     "docs\\.nestjs\\.com",
     "courses\\.nestjs\\.com",
+    "martendb\\.io",
     "opentelemetry\\.io",
     "masstransit\\.io",
     "kubernetes\\.io",

--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -51,6 +51,7 @@ exclude = [
     "alistair\\.cockburn\\.us",
     # Sites that frequently timeout or block CI
     "docs\\.nestjs\\.com",
+    "courses\\.nestjs\\.com",
     "opentelemetry\\.io",
     "masstransit\\.io",
     "kubernetes\\.io",

--- a/tests/Encina.GuardTests/NATS/NATSGuardTests.cs
+++ b/tests/Encina.GuardTests/NATS/NATSGuardTests.cs
@@ -123,7 +123,7 @@ public sealed class NATSGuardTests
     }
 
     [Fact]
-    public void AddEncinaNATS_ValidServices_RegistersExpectedServices()
+    public void AddEncinaNATS_ValidServices_RegistersPublisher()
     {
         var services = new ServiceCollection();
         services.AddLogging();

--- a/tests/Encina.GuardTests/NATS/NATSGuardTests.cs
+++ b/tests/Encina.GuardTests/NATS/NATSGuardTests.cs
@@ -77,8 +77,8 @@ public sealed class NATSGuardTests
             NullLogger<NATSMessagePublisher>.Instance,
             Options.Create(new EncinaNATSOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.PublishAsync<object>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.PublishAsync<object>(null!));
     }
 
     [Fact]
@@ -88,8 +88,8 @@ public sealed class NATSGuardTests
             NullLogger<NATSMessagePublisher>.Instance,
             Options.Create(new EncinaNATSOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.RequestAsync<object, string>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.RequestAsync<object, string>(null!));
     }
 
     [Fact]
@@ -99,8 +99,8 @@ public sealed class NATSGuardTests
             NullLogger<NATSMessagePublisher>.Instance,
             Options.Create(new EncinaNATSOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.JetStreamPublishAsync<object>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await sut.JetStreamPublishAsync<object>(null!));
     }
 
     // ─── NATSHealthCheck ───
@@ -132,7 +132,13 @@ public sealed class NATSGuardTests
             o.Url = "nats://localhost:4222");
 
         result.ShouldNotBeNull();
-        services.ShouldContain(sd => sd.ServiceType == typeof(INATSMessagePublisher));
+
+        var publisherDescriptors = services
+            .Where(sd => sd.ServiceType == typeof(INATSMessagePublisher))
+            .ToList();
+        publisherDescriptors.Count.ShouldBe(1);
+        publisherDescriptors[0].ImplementationType.ShouldBe(typeof(NATSMessagePublisher));
+        publisherDescriptors[0].Lifetime.ShouldBe(ServiceLifetime.Scoped);
     }
 
     // ─── EncinaNATSOptions ───

--- a/tests/Encina.GuardTests/NATS/NATSGuardTests.cs
+++ b/tests/Encina.GuardTests/NATS/NATSGuardTests.cs
@@ -77,8 +77,8 @@ public sealed class NATSGuardTests
             NullLogger<NATSMessagePublisher>.Instance,
             Options.Create(new EncinaNATSOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.PublishAsync<object>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.PublishAsync<object>(null!).AsTask());
     }
 
     [Fact]
@@ -88,8 +88,8 @@ public sealed class NATSGuardTests
             NullLogger<NATSMessagePublisher>.Instance,
             Options.Create(new EncinaNATSOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.RequestAsync<object, string>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.RequestAsync<object, string>(null!).AsTask());
     }
 
     [Fact]
@@ -99,8 +99,8 @@ public sealed class NATSGuardTests
             NullLogger<NATSMessagePublisher>.Instance,
             Options.Create(new EncinaNATSOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.JetStreamPublishAsync<object>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.JetStreamPublishAsync<object>(null!).AsTask());
     }
 
     // ─── NATSHealthCheck ───
@@ -139,6 +139,16 @@ public sealed class NATSGuardTests
         publisherDescriptors.Count.ShouldBe(1);
         publisherDescriptors[0].ImplementationType.ShouldBe(typeof(NATSMessagePublisher));
         publisherDescriptors[0].Lifetime.ShouldBe(ServiceLifetime.Scoped);
+
+        var connectionDescriptors = services
+            .Where(sd => sd.ServiceType == typeof(INatsConnection))
+            .ToList();
+        connectionDescriptors.Count.ShouldBe(1);
+        connectionDescriptors[0].Lifetime.ShouldBe(ServiceLifetime.Singleton);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<EncinaNATSOptions>>();
+        options.Value.Url.ShouldBe("nats://localhost:4222");
     }
 
     // ─── EncinaNATSOptions ───

--- a/tests/Encina.GuardTests/NATS/NATSGuardTests.cs
+++ b/tests/Encina.GuardTests/NATS/NATSGuardTests.cs
@@ -77,8 +77,8 @@ public sealed class NATSGuardTests
             NullLogger<NATSMessagePublisher>.Instance,
             Options.Create(new EncinaNATSOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.PublishAsync<object>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.PublishAsync<object>(null!));
     }
 
     [Fact]
@@ -88,8 +88,8 @@ public sealed class NATSGuardTests
             NullLogger<NATSMessagePublisher>.Instance,
             Options.Create(new EncinaNATSOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.RequestAsync<object, string>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.RequestAsync<object, string>(null!));
     }
 
     [Fact]
@@ -99,8 +99,8 @@ public sealed class NATSGuardTests
             NullLogger<NATSMessagePublisher>.Instance,
             Options.Create(new EncinaNATSOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.JetStreamPublishAsync<object>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.JetStreamPublishAsync<object>(null!));
     }
 
     // ─── NATSHealthCheck ───
@@ -108,7 +108,7 @@ public sealed class NATSGuardTests
     [Fact]
     public void NATSHealthCheck_Constructs()
     {
-        var sp = new ServiceCollection().BuildServiceProvider();
+        using var sp = new ServiceCollection().BuildServiceProvider();
         var sut = new NATSHealthCheck(sp, null);
         sut.ShouldNotBeNull();
     }
@@ -123,14 +123,16 @@ public sealed class NATSGuardTests
     }
 
     [Fact]
-    public void AddEncinaNATS_ValidServices_Registers()
+    public void AddEncinaNATS_ValidServices_RegistersExpectedServices()
     {
         var services = new ServiceCollection();
         services.AddLogging();
 
         var result = services.AddEncinaNATS(o =>
             o.Url = "nats://localhost:4222");
+
         result.ShouldNotBeNull();
+        services.ShouldContain(sd => sd.ServiceType == typeof(INATSMessagePublisher));
     }
 
     // ─── EncinaNATSOptions ───
@@ -139,7 +141,16 @@ public sealed class NATSGuardTests
     public void EncinaNATSOptions_Defaults()
     {
         var options = new EncinaNATSOptions();
+
         options.ShouldNotBeNull();
+        options.Url.ShouldBe("nats://localhost:4222");
+        options.SubjectPrefix.ShouldBe("encina");
+        options.UseJetStream.ShouldBeFalse();
+        options.StreamName.ShouldBe("ENCINA");
+        options.ConsumerName.ShouldBe("encina-consumer");
+        options.UseDurableConsumer.ShouldBeTrue();
+        options.AckWait.ShouldBe(TimeSpan.FromSeconds(30));
+        options.MaxDeliver.ShouldBe(5);
     }
 
     // ─── NATSPublishAck record ───

--- a/tests/Encina.GuardTests/NATS/NATSGuardTests.cs
+++ b/tests/Encina.GuardTests/NATS/NATSGuardTests.cs
@@ -142,7 +142,6 @@ public sealed class NATSGuardTests
     {
         var options = new EncinaNATSOptions();
 
-        options.ShouldNotBeNull();
         options.Url.ShouldBe("nats://localhost:4222");
         options.SubjectPrefix.ShouldBe("encina");
         options.UseJetStream.ShouldBeFalse();


### PR DESCRIPTION
## Summary

Addresses Copilot review findings from merged PR #974.

### Changes

1. **Defaults test**: asserts all 8 default property values for `EncinaNATSOptions`
2. **Registration test**: verifies `INATSMessagePublisher` is registered
3. **Dispose**: added `using` to `ServiceProvider`
4. **Simplified async**: removed redundant `async/await` in 3 ThrowAsync assertions

### Related

- Addresses review comments from Copilot on #974

### Test plan

- [x] `dotnet test --filter NATSGuardTests` — 13 tests pass
- [ ] CI guard tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reforzadas las pruebas con aserciones más exhaustivas, comprobaciones de valores por defecto y mejora en la gestión del ciclo de vida de recursos para mayor fiabilidad de las pruebas.
* **Chores**
  * Actualizada la configuración del comprobador de enlaces para excluir un dominio adicional, evitando comprobaciones innecesarias de URLs externas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->