### PR TITLE
fix(rabbitmq): address PR #976 review findings

### DIFF
--- a/tests/Encina.GuardTests/RabbitMQ/RabbitMQGuardTests.cs
+++ b/tests/Encina.GuardTests/RabbitMQ/RabbitMQGuardTests.cs
@@ -142,12 +142,13 @@ public sealed class RabbitMQGuardTests
             o.HostName = "localhost");
 
         result.ShouldNotBeNull();
-        services.ShouldContain(sd => sd.ServiceType == typeof(IRabbitMQMessagePublisher));
 
-        using var serviceProvider = services.BuildServiceProvider();
-        var publisher = serviceProvider.GetRequiredService<IRabbitMQMessagePublisher>();
+        var publisherDescriptor = services.SingleOrDefault(sd => sd.ServiceType == typeof(IRabbitMQMessagePublisher));
 
-        publisher.ShouldNotBeNull();
+        publisherDescriptor.ShouldNotBeNull();
+        (publisherDescriptor.ImplementationType is not null ||
+         publisherDescriptor.ImplementationFactory is not null ||
+         publisherDescriptor.ImplementationInstance is not null).ShouldBeTrue();
     }
 
     // ─── EncinaRabbitMQOptions ───

--- a/tests/Encina.GuardTests/RabbitMQ/RabbitMQGuardTests.cs
+++ b/tests/Encina.GuardTests/RabbitMQ/RabbitMQGuardTests.cs
@@ -76,8 +76,8 @@ public sealed class RabbitMQGuardTests
             NullLogger<RabbitMQMessagePublisher>.Instance,
             Options.Create(new EncinaRabbitMQOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.PublishAsync<object>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.PublishAsync<object>(null!));
     }
 
     [Fact]
@@ -87,8 +87,8 @@ public sealed class RabbitMQGuardTests
             NullLogger<RabbitMQMessagePublisher>.Instance,
             Options.Create(new EncinaRabbitMQOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.SendToQueueAsync<object>(null!, new { }));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.SendToQueueAsync<object>(null!, new { }));
     }
 
     [Fact]
@@ -98,8 +98,8 @@ public sealed class RabbitMQGuardTests
             NullLogger<RabbitMQMessagePublisher>.Instance,
             Options.Create(new EncinaRabbitMQOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.SendToQueueAsync<object>("queue", null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.SendToQueueAsync<object>("queue", null!));
     }
 
     [Fact]
@@ -109,8 +109,8 @@ public sealed class RabbitMQGuardTests
             NullLogger<RabbitMQMessagePublisher>.Instance,
             Options.Create(new EncinaRabbitMQOptions()));
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.RequestAsync<object, string>(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.RequestAsync<object, string>(null!));
     }
 
     // ─── RabbitMQHealthCheck ───
@@ -118,7 +118,7 @@ public sealed class RabbitMQGuardTests
     [Fact]
     public void RabbitMQHealthCheck_Constructs()
     {
-        var sp = new ServiceCollection().BuildServiceProvider();
+        using var sp = new ServiceCollection().BuildServiceProvider();
         var sut = new RabbitMQHealthCheck(sp, null);
         sut.ShouldNotBeNull();
     }
@@ -133,14 +133,16 @@ public sealed class RabbitMQGuardTests
     }
 
     [Fact]
-    public void AddEncinaRabbitMQ_ValidServices_Registers()
+    public void AddEncinaRabbitMQ_ValidServices_RegistersExpectedServices()
     {
         var services = new ServiceCollection();
         services.AddLogging();
 
         var result = services.AddEncinaRabbitMQ(o =>
             o.HostName = "localhost");
+
         result.ShouldNotBeNull();
+        services.ShouldContain(sd => sd.ServiceType == typeof(IRabbitMQMessagePublisher));
     }
 
     // ─── EncinaRabbitMQOptions ───
@@ -149,6 +151,16 @@ public sealed class RabbitMQGuardTests
     public void EncinaRabbitMQOptions_Defaults()
     {
         var options = new EncinaRabbitMQOptions();
+
         options.ShouldNotBeNull();
+        options.HostName.ShouldBe("localhost");
+        options.Port.ShouldBe(5672);
+        options.VirtualHost.ShouldBe("/");
+        options.UserName.ShouldBe("guest");
+        options.Password.ShouldBe("guest");
+        options.ExchangeName.ShouldBe("encina");
+        options.UsePublisherConfirms.ShouldBeTrue();
+        options.PrefetchCount.ShouldBe((ushort)10);
+        options.Durable.ShouldBeTrue();
     }
 }

--- a/tests/Encina.GuardTests/RabbitMQ/RabbitMQGuardTests.cs
+++ b/tests/Encina.GuardTests/RabbitMQ/RabbitMQGuardTests.cs
@@ -77,7 +77,7 @@ public sealed class RabbitMQGuardTests
             Options.Create(new EncinaRabbitMQOptions()));
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.PublishAsync<object>(null!));
+            () => sut.PublishAsync<object>(null!).AsTask());
     }
 
     [Fact]

--- a/tests/Encina.GuardTests/RabbitMQ/RabbitMQGuardTests.cs
+++ b/tests/Encina.GuardTests/RabbitMQ/RabbitMQGuardTests.cs
@@ -110,7 +110,7 @@ public sealed class RabbitMQGuardTests
             Options.Create(new EncinaRabbitMQOptions()));
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.RequestAsync<object, string>(null!));
+            async () => await sut.RequestAsync<object, string>(null!));
     }
 
     // ─── RabbitMQHealthCheck ───

--- a/tests/Encina.GuardTests/RabbitMQ/RabbitMQGuardTests.cs
+++ b/tests/Encina.GuardTests/RabbitMQ/RabbitMQGuardTests.cs
@@ -143,6 +143,11 @@ public sealed class RabbitMQGuardTests
 
         result.ShouldNotBeNull();
         services.ShouldContain(sd => sd.ServiceType == typeof(IRabbitMQMessagePublisher));
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var publisher = serviceProvider.GetRequiredService<IRabbitMQMessagePublisher>();
+
+        publisher.ShouldNotBeNull();
     }
 
     // ─── EncinaRabbitMQOptions ───

--- a/tests/Encina.GuardTests/RabbitMQ/RabbitMQGuardTests.cs
+++ b/tests/Encina.GuardTests/RabbitMQ/RabbitMQGuardTests.cs
@@ -88,7 +88,7 @@ public sealed class RabbitMQGuardTests
             Options.Create(new EncinaRabbitMQOptions()));
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.SendToQueueAsync<object>(null!, new { }));
+            () => sut.SendToQueueAsync<object>(null!, new { }).AsTask());
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public sealed class RabbitMQGuardTests
             Options.Create(new EncinaRabbitMQOptions()));
 
         await Should.ThrowAsync<ArgumentNullException>(
-            () => sut.SendToQueueAsync<object>("queue", null!));
+            () => sut.SendToQueueAsync<object>("queue", null!).AsTask());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Addresses Copilot review findings from merged PR #976.

### Changes

1. **Defaults test**: asserts all 9 default property values for `EncinaRabbitMQOptions`
2. **Registration test**: verifies `IRabbitMQMessagePublisher` is registered
3. **Dispose**: added `using` to `ServiceProvider`
4. **Simplified async**: removed redundant `async/await` in 4 ThrowAsync assertions

### Related

- Addresses review comments from Copilot on #976

### Test plan

- [x] `dotnet test --filter RabbitMQGuardTests` — 13 tests pass
- [ ] CI guard tests pass