### PR TITLE
fix(aspire-testing): address PR #980 review findings

### DIFF
--- a/tests/Encina.GuardTests/Aspire/AspireTestingGuardTests.cs
+++ b/tests/Encina.GuardTests/Aspire/AspireTestingGuardTests.cs
@@ -151,7 +151,6 @@ public sealed class AspireTestingGuardTests
     {
         var options = new EncinaTestSupportOptions();
 
-        options.ShouldNotBeNull();
         options.ClearOutboxBeforeTest.ShouldBeTrue();
         options.ClearInboxBeforeTest.ShouldBeTrue();
         options.ResetSagasBeforeTest.ShouldBeTrue();

--- a/tests/Encina.GuardTests/Aspire/AspireTestingGuardTests.cs
+++ b/tests/Encina.GuardTests/Aspire/AspireTestingGuardTests.cs
@@ -1,5 +1,3 @@
-using Aspire.Hosting;
-
 using Encina.Aspire.Testing;
 
 using Shouldly;
@@ -61,22 +59,22 @@ public sealed class AspireTestingGuardTests
     [Fact]
     public async Task AssertOutboxContainsAsync_NullApp_Throws()
     {
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await DistributedApplicationExtensions.AssertOutboxContainsAsync(null!, _ => true));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => DistributedApplicationExtensions.AssertOutboxContainsAsync(null!, _ => true));
     }
 
     [Fact]
     public async Task AssertInboxProcessedAsync_NullApp_Throws()
     {
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await DistributedApplicationExtensions.AssertInboxProcessedAsync(null!, "msg-1"));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => DistributedApplicationExtensions.AssertInboxProcessedAsync(null!, "msg-1"));
     }
 
     [Fact]
     public async Task WaitForOutboxProcessingAsync_NullApp_Throws()
     {
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await DistributedApplicationExtensions.WaitForOutboxProcessingAsync(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => DistributedApplicationExtensions.WaitForOutboxProcessingAsync(null!));
     }
 
     // ─── FailureSimulationExtensions null guards ───
@@ -126,8 +124,8 @@ public sealed class AspireTestingGuardTests
     [Fact]
     public async Task AddToDeadLetterAsync_NullApp_Throws()
     {
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await FailureSimulationExtensions.AddToDeadLetterAsync(null!, "type", "content"));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => FailureSimulationExtensions.AddToDeadLetterAsync(null!, "type", "content"));
     }
 
     // ─── EncinaTestContext ───
@@ -152,6 +150,14 @@ public sealed class AspireTestingGuardTests
     public void EncinaTestSupportOptions_Defaults()
     {
         var options = new EncinaTestSupportOptions();
+
         options.ShouldNotBeNull();
+        options.ClearOutboxBeforeTest.ShouldBeTrue();
+        options.ClearInboxBeforeTest.ShouldBeTrue();
+        options.ResetSagasBeforeTest.ShouldBeTrue();
+        options.ClearScheduledMessagesBeforeTest.ShouldBeTrue();
+        options.ClearDeadLetterBeforeTest.ShouldBeTrue();
+        options.DefaultWaitTimeout.ShouldBe(TimeSpan.FromSeconds(30));
+        options.PollingInterval.ShouldBe(TimeSpan.FromMilliseconds(100));
     }
 }

--- a/tests/Encina.GuardTests/Aspire/AspireTestingGuardTests.cs
+++ b/tests/Encina.GuardTests/Aspire/AspireTestingGuardTests.cs
@@ -17,64 +17,73 @@ public sealed class AspireTestingGuardTests
     [Fact]
     public void GetEncinaTestContext_NullApp_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             DistributedApplicationExtensions.GetEncinaTestContext(null!));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public void GetOutboxStore_NullApp_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             DistributedApplicationExtensions.GetOutboxStore(null!));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public void GetInboxStore_NullApp_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             DistributedApplicationExtensions.GetInboxStore(null!));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public void GetSagaStore_NullApp_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             DistributedApplicationExtensions.GetSagaStore(null!));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public void GetPendingOutboxMessages_NullApp_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             DistributedApplicationExtensions.GetPendingOutboxMessages(null!));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public void GetDeadLetterMessages_NullApp_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             DistributedApplicationExtensions.GetDeadLetterMessages(null!));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public async Task AssertOutboxContainsAsync_NullApp_Throws()
     {
-        await Should.ThrowAsync<ArgumentNullException>(
+        var ex = await Should.ThrowAsync<ArgumentNullException>(
             () => DistributedApplicationExtensions.AssertOutboxContainsAsync(null!, _ => true));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public async Task AssertInboxProcessedAsync_NullApp_Throws()
     {
-        await Should.ThrowAsync<ArgumentNullException>(
+        var ex = await Should.ThrowAsync<ArgumentNullException>(
             () => DistributedApplicationExtensions.AssertInboxProcessedAsync(null!, "msg-1"));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public async Task WaitForOutboxProcessingAsync_NullApp_Throws()
     {
-        await Should.ThrowAsync<ArgumentNullException>(
+        var ex = await Should.ThrowAsync<ArgumentNullException>(
             () => DistributedApplicationExtensions.WaitForOutboxProcessingAsync(null!));
+        ex.ParamName.ShouldBe("app");
     }
 
     // ─── FailureSimulationExtensions null guards ───
@@ -82,50 +91,57 @@ public sealed class AspireTestingGuardTests
     [Fact]
     public void SimulateSagaTimeout_NullApp_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             FailureSimulationExtensions.SimulateSagaTimeout(null!, Guid.NewGuid()));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public void SimulateSagaFailure_NullApp_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             FailureSimulationExtensions.SimulateSagaFailure(null!, Guid.NewGuid(), "error"));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public void SimulateOutboxMessageFailure_NullApp_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             FailureSimulationExtensions.SimulateOutboxMessageFailure(null!, Guid.NewGuid()));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public void SimulateOutboxDeadLetter_NullApp_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             FailureSimulationExtensions.SimulateOutboxDeadLetter(null!, Guid.NewGuid()));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public void SimulateInboxMessageFailure_NullApp_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             FailureSimulationExtensions.SimulateInboxMessageFailure(null!, "msg-1"));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public void SimulateInboxExpiration_NullApp_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             FailureSimulationExtensions.SimulateInboxExpiration(null!, "msg-1"));
+        ex.ParamName.ShouldBe("app");
     }
 
     [Fact]
     public async Task AddToDeadLetterAsync_NullApp_Throws()
     {
-        await Should.ThrowAsync<ArgumentNullException>(
+        var ex = await Should.ThrowAsync<ArgumentNullException>(
             () => FailureSimulationExtensions.AddToDeadLetterAsync(null!, "type", "content"));
+        ex.ParamName.ShouldBe("app");
     }
 
     // ─── EncinaTestContext ───
@@ -133,8 +149,9 @@ public sealed class AspireTestingGuardTests
     [Fact]
     public void EncinaTestContext_NullOptions_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             new EncinaTestContext(null!));
+        ex.ParamName.ShouldBe("options");
     }
 
     [Fact]

--- a/tests/Encina.GuardTests/Aspire/AspireTestingGuardTests.cs
+++ b/tests/Encina.GuardTests/Aspire/AspireTestingGuardTests.cs
@@ -157,8 +157,11 @@ public sealed class AspireTestingGuardTests
     [Fact]
     public void EncinaTestContext_ValidOptions_Constructs()
     {
-        var sut = new EncinaTestContext(new EncinaTestSupportOptions());
-        sut.ShouldNotBeNull();
+        var options = new EncinaTestSupportOptions();
+
+        var sut = new EncinaTestContext(options);
+
+        sut.Options.ShouldBeSameAs(options);
     }
 
     // ─── EncinaTestSupportOptions ───


### PR DESCRIPTION
## Summary

Addresses Copilot review findings from merged PR #980.

### Changes

1. **Unused using**: removed `Aspire.Hosting` import
2. **Defaults test**: asserts all 7 default property values for `EncinaTestSupportOptions`
3. **Simplified async**: removed redundant `async/await` in 4 ThrowAsync assertions

### Related

- Addresses review comments from Copilot on #980

### Test plan

- [x] `dotnet test --filter AspireTestingGuardTests` — 19 tests pass
- [ ] CI guard tests pass