### PR TITLE
fix(testing-verify): address PR #987 review findings

### DIFF
--- a/tests/Encina.GuardTests/Testing/Verify/VerifyGuardTests.cs
+++ b/tests/Encina.GuardTests/Testing/Verify/VerifyGuardTests.cs
@@ -171,12 +171,4 @@ public sealed class VerifyGuardTests
         prepared.ShouldNotBeNull();
     }
 
-    // ─── EncinaVerifySettings ───
-
-    [Fact]
-    public void EncinaVerifySettings_Constructs()
-    {
-        var settings = new EncinaVerifySettings();
-        settings.ShouldNotBeNull();
-    }
 }

--- a/tests/Encina.GuardTests/Testing/Verify/VerifyGuardTests.cs
+++ b/tests/Encina.GuardTests/Testing/Verify/VerifyGuardTests.cs
@@ -1,12 +1,6 @@
-using Encina.Messaging.Inbox;
-using Encina.Messaging.Outbox;
-using Encina.Messaging.Sagas;
-using Encina.Messaging.Scheduling;
 using Encina.Testing.Verify;
 
 using LanguageExt;
-
-using NSubstitute;
 
 using Shouldly;
 
@@ -180,8 +174,9 @@ public sealed class VerifyGuardTests
     // ─── EncinaVerifySettings ───
 
     [Fact]
-    public void EncinaVerifySettings_Type_Exists()
+    public void EncinaVerifySettings_Constructs()
     {
-        typeof(EncinaVerifySettings).ShouldNotBeNull();
+        var settings = new EncinaVerifySettings();
+        settings.ShouldNotBeNull();
     }
 }


### PR DESCRIPTION
## Summary

Addresses Copilot review findings from merged PR #987.

### Changes

1. **Unused usings**: removed `Encina.Messaging.Inbox`, `Encina.Messaging.Outbox`, `Encina.Messaging.Sagas`, `Encina.Messaging.Scheduling`, `NSubstitute` (none referenced)
2. **Tautological test**: replaced `typeof(EncinaVerifySettings).ShouldNotBeNull()` (always passes) with `new EncinaVerifySettings()` construction test

### Related

- Addresses review comments from Copilot on #987

### Test plan

- [x] `dotnet test --filter VerifyGuardTests` — 19 tests pass
- [ ] CI guard tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la Versión

* **Tests**
  * Se optimizaron las pruebas internas eliminando dependencias no utilizadas.
  * Se mejoró la validación de componentes de prueba para mayor robustez.

**Nota:** Esta versión contiene mejoras internas sin cambios visibles para los usuarios finales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->