### PR TITLE
fix(hangfire): address PR #989 review findings

### DIFF
--- a/.github/coverage-manifest/Encina.Hangfire.json
+++ b/.github/coverage-manifest/Encina.Hangfire.json
@@ -27,7 +27,7 @@
         "property"
       ],
       "defaultRule": "*Adapter.cs",
-      "reason": "Job adapter with constructor null guards and ExecuteAsync method guard. Property tests verify notification round-trip invariants."
+      "reason": "Job adapter with constructor null guards and PublishAsync method guard. Property tests verify notification round-trip invariants."
     },
     "HangfireRequestJobAdapter.cs": {
       "defaultTests": [
@@ -45,7 +45,7 @@
         "property"
       ],
       "defaultRule": "*HealthCheck.cs",
-      "reason": "Health check with mockeable service dependencies. Property tests exercise health check invariants."
+      "reason": "Health check with mockable service dependencies. Property tests exercise health check invariants."
     },
     "Log.cs": {
       "defaultTests": [],

--- a/tests/Encina.GuardTests/Hangfire/HangfireGuardTests.cs
+++ b/tests/Encina.GuardTests/Hangfire/HangfireGuardTests.cs
@@ -50,8 +50,8 @@ public sealed class HangfireGuardTests
         var sut = new HangfireNotificationJobAdapter<TestNotification>(encina,
             NullLogger<HangfireNotificationJobAdapter<TestNotification>>.Instance);
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.PublishAsync(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.PublishAsync(null!));
     }
 
     // ─── HangfireRequestJobAdapter constructor guards ───
@@ -88,8 +88,8 @@ public sealed class HangfireGuardTests
         var sut = new HangfireRequestJobAdapter<TestRequest, TestResponse>(encina,
             NullLogger<HangfireRequestJobAdapter<TestRequest, TestResponse>>.Instance);
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.ExecuteAsync(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.ExecuteAsync(null!));
     }
 
     // ─── HangfireHealthCheck ───
@@ -97,7 +97,7 @@ public sealed class HangfireGuardTests
     [Fact]
     public void HangfireHealthCheck_Constructs()
     {
-        var sp = new ServiceCollection().BuildServiceProvider();
+        using var sp = new ServiceCollection().BuildServiceProvider();
         var sut = new HangfireHealthCheck(sp, null);
         sut.ShouldNotBeNull();
     }
@@ -108,7 +108,9 @@ public sealed class HangfireGuardTests
     public void EncinaHangfireOptions_Defaults()
     {
         var options = new EncinaHangfireOptions();
+
         options.ShouldNotBeNull();
+        options.ProviderHealthCheck.ShouldNotBeNull();
     }
 
     // ─── Test types ───


### PR DESCRIPTION
## Summary

Addresses Copilot review findings from merged PR #989.

### Changes

1. **Defaults test**: asserts `ProviderHealthCheck` property is not null (EncinaHangfireOptions only has this one property)
2. **Dispose**: added `using` to `ServiceProvider`
3. **Simplified async**: removed redundant `async/await` in 2 ThrowAsync assertions
4. **Manifest wording**: fixed `mockeable` → `mockable`; reason for `HangfireNotificationJobAdapter.cs` referenced `ExecuteAsync` but the actual guard is on `PublishAsync`

### Related

- Addresses review comments from Copilot on #989

### Test plan

- [x] `dotnet test --filter HangfireGuardTests` — 10 tests pass
- [ ] CI guard tests pass