### PR TITLE
fix(quartz): address PR #991 review findings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -175,6 +175,7 @@
     <PackageVersion Include="AWSSDK.KeyManagementService" Version="4.0.9.1" />
     <!-- Data Protection -->
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.3" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageVersion Include="VaultSharp" Version="1.17.5.1" />
     <PackageVersion Include="Google.Cloud.SecretManager.V1" Version="2.7.0" />
     <!-- YAML Parsing -->

--- a/src/Encina.Messaging.Encryption.DataProtection/Encina.Messaging.Encryption.DataProtection.csproj
+++ b/src/Encina.Messaging.Encryption.DataProtection/Encina.Messaging.Encryption.DataProtection.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />

--- a/tests/Encina.GuardTests/Quartz/QuartzGuardTests.cs
+++ b/tests/Encina.GuardTests/Quartz/QuartzGuardTests.cs
@@ -1,3 +1,4 @@
+using Encina.Messaging.Health;
 using Encina.Quartz;
 
 using Microsoft.Extensions.Logging.Abstractions;
@@ -105,6 +106,11 @@ public sealed class QuartzGuardTests
 
         options.ShouldNotBeNull();
         options.ProviderHealthCheck.ShouldNotBeNull();
+        options.ProviderHealthCheck.Enabled.ShouldBeTrue();
+        options.ProviderHealthCheck.Timeout.ShouldBe(TimeSpan.FromSeconds(5));
+        options.ProviderHealthCheck.Name.ShouldBeNull();
+        options.ProviderHealthCheck.Tags.ShouldBe(["encina", "database", "ready"]);
+        options.ProviderHealthCheck.FailureStatus.ShouldBe(HealthStatus.Unhealthy);
     }
 
     public sealed record TestNotification : INotification;

--- a/tests/Encina.GuardTests/Quartz/QuartzGuardTests.cs
+++ b/tests/Encina.GuardTests/Quartz/QuartzGuardTests.cs
@@ -21,17 +21,19 @@ public sealed class QuartzGuardTests
     [Fact]
     public void NotificationJob_NullEncina_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             new QuartzNotificationJob<TestNotification>(null!,
                 NullLogger<QuartzNotificationJob<TestNotification>>.Instance));
+        ex.ParamName.ShouldBe("encina");
     }
 
     [Fact]
     public void NotificationJob_NullLogger_Throws()
     {
         var encina = Substitute.For<IEncina>();
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             new QuartzNotificationJob<TestNotification>(encina, null!));
+        ex.ParamName.ShouldBe("logger");
     }
 
     [Fact]
@@ -50,8 +52,8 @@ public sealed class QuartzGuardTests
         var sut = new QuartzNotificationJob<TestNotification>(encina,
             NullLogger<QuartzNotificationJob<TestNotification>>.Instance);
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.Execute(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.Execute(null!));
     }
 
     // ─── QuartzRequestJob constructor guards ───
@@ -59,17 +61,19 @@ public sealed class QuartzGuardTests
     [Fact]
     public void RequestJob_NullEncina_Throws()
     {
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             new QuartzRequestJob<TestRequest, TestResponse>(null!,
                 NullLogger<QuartzRequestJob<TestRequest, TestResponse>>.Instance));
+        ex.ParamName.ShouldBe("encina");
     }
 
     [Fact]
     public void RequestJob_NullLogger_Throws()
     {
         var encina = Substitute.For<IEncina>();
-        Should.Throw<ArgumentNullException>(() =>
+        var ex = Should.Throw<ArgumentNullException>(() =>
             new QuartzRequestJob<TestRequest, TestResponse>(encina, null!));
+        ex.ParamName.ShouldBe("logger");
     }
 
     [Fact]
@@ -88,8 +92,8 @@ public sealed class QuartzGuardTests
         var sut = new QuartzRequestJob<TestRequest, TestResponse>(encina,
             NullLogger<QuartzRequestJob<TestRequest, TestResponse>>.Instance);
 
-        await Should.ThrowAsync<ArgumentNullException>(async () =>
-            await sut.Execute(null!));
+        await Should.ThrowAsync<ArgumentNullException>(
+            () => sut.Execute(null!));
     }
 
     // ─── EncinaQuartzOptions ───
@@ -98,7 +102,9 @@ public sealed class QuartzGuardTests
     public void EncinaQuartzOptions_Defaults()
     {
         var options = new EncinaQuartzOptions();
+
         options.ShouldNotBeNull();
+        options.ProviderHealthCheck.ShouldNotBeNull();
     }
 
     public sealed record TestNotification : INotification;


### PR DESCRIPTION
## Summary

Addresses Copilot review findings from merged PR #991, plus a CI unblock for a newly-published CVE.

### Changes

#### Quartz review findings (PR #991)
1. **ParamName assertions**: 4 constructor guard tests now verify `ArgumentNullException.ParamName` (`encina`, `logger`).
2. **Strengthened defaults test** (`EncinaQuartzOptions_Defaults`): asserts the specific default values of `ProviderHealthCheck` (`Enabled=true`, `Timeout=5s`, `Name=null`, `Tags=[encina,database,ready]`, `FailureStatus=Unhealthy`) instead of only non-null. The `HealthStatus` symbol resolves via `using Encina.Messaging.Health;` — this is Encina's own `HealthStatus` enum (not `Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus`), matching the type of `ProviderHealthCheckOptions.FailureStatus`.
3. **Simplified async**: removed redundant `async/await` in 2 `ThrowAsync` assertions.

#### Dependency security fix (unblocks CI on this PR)
4. **`System.Security.Cryptography.Xml` pinned to 10.0.6** to patch two newly-published advisories (`GHSA-37gx-xxp4-5rgx`, `GHSA-w3x6-4m5h-cxqf`) that were flowing in transitively via `Microsoft.AspNetCore.DataProtection 10.0.3`. With `NU1901` treated as error, restore was failing on every PR (including this one) after the advisory publication. `Microsoft.AspNetCore.DataProtection` stays at 10.0.3 because bumping to 10.0.6 would cascade `Microsoft.Extensions.*` to 10.0.6 and conflict with existing pins — that broader update is tracked in #1023. The fix here is surgical: override only the vulnerable transitive.

### Related

- Addresses review comments from Copilot on #991
- Advisory fix unblocks #1016 CI; broader dependency refresh tracked in #1023 (sub-issue of EPIC #871)

### Test plan

- [x] `dotnet test --filter QuartzGuardTests` — 9 tests pass locally
- [x] `dotnet restore` + `dotnet build src/Encina.Messaging.Encryption.DataProtection` — 0 warnings, 0 errors
- [ ] CI guard tests pass