### PR TITLE
fix(sanitization): address PR #996 review findings

### DIFF
--- a/.github/coverage-manifest/Encina.Security.Sanitization.json
+++ b/.github/coverage-manifest/Encina.Security.Sanitization.json
@@ -1,13 +1,16 @@
 {
   "package": "Encina.Security.Sanitization",
   "generated": "2026-04-13T00:00:00Z",
-  "totalFiles": 32,
+  "totalFiles": 35,
   "targets": {
     "guard": 20,
     "unit": 70,
     "property": 27
   },
   "files": {
+    "Abstractions/IOutputEncoder.cs": { "defaultTests": [], "defaultRule": "^I[A-Z].*\\.cs$", "reason": "Interfaces have no implementation to test" },
+    "Abstractions/ISanitizationProfile.cs": { "defaultTests": [], "defaultRule": "^I[A-Z].*\\.cs$", "reason": "Interfaces have no implementation to test" },
+    "Abstractions/ISanitizer.cs": { "defaultTests": [], "defaultRule": "^I[A-Z].*\\.cs$", "reason": "Interfaces have no implementation to test" },
     "Attributes/EncodeForHtmlAttribute.cs": { "defaultTests": ["unit"], "reason": "Attribute — no guards" },
     "Attributes/EncodeForJavaScriptAttribute.cs": { "defaultTests": ["unit"], "reason": "Attribute — no guards" },
     "Attributes/EncodeForUrlAttribute.cs": { "defaultTests": ["unit"], "reason": "Attribute — no guards" },

--- a/.github/coverage-manifest/Encina.Security.Sanitization.json
+++ b/.github/coverage-manifest/Encina.Security.Sanitization.json
@@ -1,7 +1,7 @@
 {
   "package": "Encina.Security.Sanitization",
   "generated": "2026-04-13T00:00:00Z",
-  "totalFiles": 31,
+  "totalFiles": 32,
   "targets": {
     "guard": 20,
     "unit": 70,

--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -50,7 +50,8 @@ exclude = [
     "docs\\.oasis-open\\.org",
     # Sites with expired SSL certificates (out of our control)
     "alistair\\.cockburn\\.us",
-    # Sites that frequently timeout or block CI
+    # Sites that frequently timeout or reset connections in CI
+    "conventionalcommits\\.org",
     "docs\\.nestjs\\.com",
     "courses\\.nestjs\\.com",
     "martendb\\.io",


### PR DESCRIPTION
## Summary

Addresses review findings from merged PR #996 (Copilot + CodeRabbit).

### Changes

- Corrected `totalFiles` from 31 to 35 to match the actual entries in `files` block
- Added 3 interface entries (`IOutputEncoder.cs`, `ISanitizationProfile.cs`, `ISanitizer.cs`) from `Abstractions/` with `defaultTests: []` (interfaces have no implementation to test)
- Added `conventionalcommits.org` to lychee exclude list (transient connection-reset errors in CI)

### Related

- Addresses review comments from Copilot and CodeRabbit on #996

### Test plan

- [x] Counted file entries: 35
- [x] `totalFiles` matches `files` block count
- [ ] Link Check workflow passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Tareas**
  * Actualización de configuración interna de cobertura de pruebas.
  * Mejora de la configuración de validación de enlaces para optimizar procesos de verificación.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->