### PR TITLE
test(aspnetcore): boost Encina.AspNetCore unit coverage

### DIFF
--- a/tests/Encina.ContractTests/Encina.ContractTests.csproj
+++ b/tests/Encina.ContractTests/Encina.ContractTests.csproj
@@ -23,6 +23,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- Override vulnerable transitive dep from Microsoft.AspNetCore.DataProtection (CVE-2026-33116). -->
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Encina.UnitTests/AspNetCore/ApplicationBuilderExtensionsTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/ApplicationBuilderExtensionsTests.cs
@@ -20,7 +20,7 @@ public sealed class ApplicationBuilderExtensionsTests
     }
 
     [Fact]
-    public void UseEncinaContext_ReturnsApplicationBuilder()
+    public void UseEncinaContext_WhenCalled_ReturnsApplicationBuilder()
     {
         using var provider = BuildProvider();
         var app = new ApplicationBuilder(provider);
@@ -32,7 +32,7 @@ public sealed class ApplicationBuilderExtensionsTests
     }
 
     [Fact]
-    public void UseEncinaContext_RegistersMiddlewareInPipeline()
+    public void UseEncinaContext_WhenBuilt_RegistersMiddlewareInPipeline()
     {
         using var provider = BuildProvider();
         var app = new ApplicationBuilder(provider);
@@ -44,7 +44,7 @@ public sealed class ApplicationBuilderExtensionsTests
     }
 
     [Fact]
-    public async Task UseEncinaContext_PipelineExecutesMiddlewareWithoutThrowing()
+    public async Task UseEncinaContext_WhenPipelineExecuted_DoesNotThrow()
     {
         using var provider = BuildProvider();
         var app = new ApplicationBuilder(provider);

--- a/tests/Encina.UnitTests/AspNetCore/ApplicationBuilderExtensionsTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/ApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,63 @@
+using Encina.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Encina.UnitTests.AspNetCore;
+
+/// <summary>
+/// Unit tests for <see cref="ApplicationBuilderExtensions"/>.
+/// </summary>
+public sealed class ApplicationBuilderExtensionsTests
+{
+    private static ApplicationBuilder CreateAppBuilder()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+        services.AddEncinaAspNetCore();
+        var provider = services.BuildServiceProvider();
+        return new ApplicationBuilder(provider);
+    }
+
+    [Fact]
+    public void UseEncinaContext_ReturnsApplicationBuilder()
+    {
+        var app = CreateAppBuilder();
+
+        var result = app.UseEncinaContext();
+
+        result.ShouldNotBeNull();
+        result.ShouldBeAssignableTo<IApplicationBuilder>();
+    }
+
+    [Fact]
+    public void UseEncinaContext_RegistersMiddlewareInPipeline()
+    {
+        var app = CreateAppBuilder();
+
+        app.UseEncinaContext();
+        var pipeline = app.Build();
+
+        pipeline.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public async Task UseEncinaContext_PipelineExecutesMiddlewareWithoutThrowing()
+    {
+        var app = CreateAppBuilder();
+        app.UseEncinaContext();
+        var pipeline = app.Build();
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = app.ApplicationServices
+        };
+
+        // The middleware should execute and pass through; the pipeline ends with no
+        // terminal handler so the response status remains 404 (default for unhandled).
+        var act = async () => await pipeline(httpContext);
+
+        await Should.NotThrowAsync(act);
+    }
+}

--- a/tests/Encina.UnitTests/AspNetCore/ApplicationBuilderExtensionsTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/ApplicationBuilderExtensionsTests.cs
@@ -10,20 +10,20 @@ namespace Encina.UnitTests.AspNetCore;
 /// </summary>
 public sealed class ApplicationBuilderExtensionsTests
 {
-    private static ApplicationBuilder CreateAppBuilder()
+    private static ServiceProvider BuildProvider()
     {
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
         services.AddEncinaAspNetCore();
-        var provider = services.BuildServiceProvider();
-        return new ApplicationBuilder(provider);
+        return services.BuildServiceProvider();
     }
 
     [Fact]
     public void UseEncinaContext_ReturnsApplicationBuilder()
     {
-        var app = CreateAppBuilder();
+        using var provider = BuildProvider();
+        var app = new ApplicationBuilder(provider);
 
         var result = app.UseEncinaContext();
 
@@ -34,7 +34,8 @@ public sealed class ApplicationBuilderExtensionsTests
     [Fact]
     public void UseEncinaContext_RegistersMiddlewareInPipeline()
     {
-        var app = CreateAppBuilder();
+        using var provider = BuildProvider();
+        var app = new ApplicationBuilder(provider);
 
         app.UseEncinaContext();
         var pipeline = app.Build();
@@ -45,7 +46,8 @@ public sealed class ApplicationBuilderExtensionsTests
     [Fact]
     public async Task UseEncinaContext_PipelineExecutesMiddlewareWithoutThrowing()
     {
-        var app = CreateAppBuilder();
+        using var provider = BuildProvider();
+        var app = new ApplicationBuilder(provider);
         app.UseEncinaContext();
         var pipeline = app.Build();
 

--- a/tests/Encina.UnitTests/AspNetCore/DPIAEndpointExtensionsTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/DPIAEndpointExtensionsTests.cs
@@ -38,6 +38,9 @@ public sealed class DPIAEndpointExtensionsTests
         }
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability", "CA2012:Use ValueTasks correctly",
+        Justification = "NSubstitute mock setup pattern for ValueTask-returning members.")]
     private static IDPIAService CreateService(
         IReadOnlyList<DPIAReadModel>? all = null,
         IReadOnlyList<DPIAReadModel>? expired = null,
@@ -47,7 +50,6 @@ public sealed class DPIAEndpointExtensionsTests
     {
         var service = Substitute.For<IDPIAService>();
 
-#pragma warning disable CA2012 // Use ValueTasks correctly - Required for NSubstitute mocking
         service.GetAllAssessmentsAsync(Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult<Either<EncinaError, IReadOnlyList<DPIAReadModel>>>(
                 Right<EncinaError, IReadOnlyList<DPIAReadModel>>(all ?? [])));
@@ -78,20 +80,20 @@ public sealed class DPIAEndpointExtensionsTests
                 Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult(rejectResult
                 ?? Right<EncinaError, Unit>(Unit.Default)));
-#pragma warning restore CA2012
 
         return service;
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability", "CA2012:Use ValueTasks correctly",
+        Justification = "NSubstitute mock setup pattern for ValueTask-returning members.")]
     private static IDPIATemplateProvider CreateTemplateProvider(
         IReadOnlyList<DPIATemplate>? templates = null)
     {
         var provider = Substitute.For<IDPIATemplateProvider>();
-#pragma warning disable CA2012 // Use ValueTasks correctly - Required for NSubstitute mocking
         provider.GetAllTemplatesAsync(Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult<Either<EncinaError, IReadOnlyList<DPIATemplate>>>(
                 Right<EncinaError, IReadOnlyList<DPIATemplate>>(templates ?? [])));
-#pragma warning restore CA2012
         return provider;
     }
 

--- a/tests/Encina.UnitTests/AspNetCore/DPIAEndpointExtensionsTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/DPIAEndpointExtensionsTests.cs
@@ -1,0 +1,377 @@
+using System.Net;
+using System.Net.Http.Json;
+using Encina.AspNetCore;
+using Encina.Compliance.DPIA;
+using Encina.Compliance.DPIA.Abstractions;
+using Encina.Compliance.DPIA.Model;
+using Encina.Compliance.DPIA.ReadModels;
+using LanguageExt;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using static LanguageExt.Prelude;
+
+#pragma warning disable CA2012 // Use ValueTasks correctly - Required for NSubstitute mocking
+
+namespace Encina.UnitTests.AspNetCore;
+
+/// <summary>
+/// Unit tests for <see cref="DPIAEndpointExtensions"/>.
+/// </summary>
+public sealed class DPIAEndpointExtensionsTests
+{
+    private static IDPIAService CreateService(
+        IReadOnlyList<DPIAReadModel>? all = null,
+        IReadOnlyList<DPIAReadModel>? expired = null,
+        DPIAReadModel? singleAssessment = null,
+        Either<EncinaError, Unit>? approveResult = null,
+        Either<EncinaError, Unit>? rejectResult = null)
+    {
+        var service = Substitute.For<IDPIAService>();
+
+        service.GetAllAssessmentsAsync(Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<Either<EncinaError, IReadOnlyList<DPIAReadModel>>>(
+                Right<EncinaError, IReadOnlyList<DPIAReadModel>>(all ?? [])));
+
+        service.GetExpiredAssessmentsAsync(Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<Either<EncinaError, IReadOnlyList<DPIAReadModel>>>(
+                Right<EncinaError, IReadOnlyList<DPIAReadModel>>(expired ?? [])));
+
+        if (singleAssessment is not null)
+        {
+            service.GetAssessmentAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+                .Returns(ValueTask.FromResult<Either<EncinaError, DPIAReadModel>>(
+                    Right<EncinaError, DPIAReadModel>(singleAssessment)));
+        }
+        else
+        {
+            service.GetAssessmentAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+                .Returns(ValueTask.FromResult<Either<EncinaError, DPIAReadModel>>(
+                    Left<EncinaError, DPIAReadModel>(DPIAErrors.AssessmentNotFound(Guid.Empty))));
+        }
+
+        service.ApproveAssessmentAsync(Arg.Any<Guid>(), Arg.Any<string>(),
+                Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(approveResult
+                ?? Right<EncinaError, Unit>(Unit.Default)));
+
+        service.RejectAssessmentAsync(Arg.Any<Guid>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(rejectResult
+                ?? Right<EncinaError, Unit>(Unit.Default)));
+
+        return service;
+    }
+
+    private static IDPIATemplateProvider CreateTemplateProvider(
+        IReadOnlyList<DPIATemplate>? templates = null)
+    {
+        var provider = Substitute.For<IDPIATemplateProvider>();
+        provider.GetAllTemplatesAsync(Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult<Either<EncinaError, IReadOnlyList<DPIATemplate>>>(
+                Right<EncinaError, IReadOnlyList<DPIATemplate>>(templates ?? [])));
+        return provider;
+    }
+
+    private static async Task<HttpClient> CreateClientAsync(
+        IDPIAService service,
+        IDPIATemplateProvider? templateProvider = null,
+        string prefix = "/api/dpia")
+    {
+        var builder = new HostBuilder()
+            .ConfigureWebHost(web =>
+            {
+                web.UseTestServer();
+                web.ConfigureServices(services =>
+                {
+                    services.AddLogging();
+                    services.AddRouting();
+                    services.AddSingleton(service);
+                    services.AddSingleton(templateProvider ?? CreateTemplateProvider());
+                    services.AddSingleton(Substitute.For<IDPIAAssessmentEngine>());
+                    services.AddSingleton(TimeProvider.System);
+                    services.Configure<DPIAOptions>(_ => { });
+                });
+                web.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapDPIAEndpoints(prefix);
+                    });
+                });
+            });
+
+        var host = await builder.StartAsync();
+        return host.GetTestClient();
+    }
+
+    // ── DTO defaults ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AssessDPIARequest_Defaults_AreEmpty()
+    {
+        var request = new AssessDPIARequest();
+
+        request.ProcessingType.ShouldBeNull();
+        request.DataCategories.ShouldBeEmpty();
+        request.HighRiskTriggers.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void AssessDPIARequest_PropertiesCanBeSet()
+    {
+        var request = new AssessDPIARequest
+        {
+            ProcessingType = "AutomatedDecisionMaking",
+            DataCategories = ["BiometricData", "HealthData"],
+            HighRiskTriggers = ["BiometricData"]
+        };
+
+        request.ProcessingType.ShouldBe("AutomatedDecisionMaking");
+        request.DataCategories.Count.ShouldBe(2);
+        request.HighRiskTriggers.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RejectDPIARequest_DefaultReason_IsNull()
+    {
+        var request = new RejectDPIARequest();
+        request.Reason.ShouldBeNull();
+    }
+
+    [Fact]
+    public void RejectDPIARequest_ReasonCanBeSet()
+    {
+        var request = new RejectDPIARequest { Reason = "Insufficient mitigation." };
+        request.Reason.ShouldBe("Insufficient mitigation.");
+    }
+
+    // ── Constants ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TenantIdHeader_Constant_Value()
+    {
+        DPIAEndpointExtensions.TenantIdHeader.ShouldBe("X-Tenant-Id");
+    }
+
+    [Fact]
+    public void ModuleIdHeader_Constant_Value()
+    {
+        DPIAEndpointExtensions.ModuleIdHeader.ShouldBe("X-Module-Id");
+    }
+
+    // ── Registration ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MapDPIAEndpoints_DefaultPrefix_ReturnsRouteGroupBuilder()
+    {
+        var endpoints = Substitute.For<IEndpointRouteBuilder>();
+        endpoints.ServiceProvider.Returns(new ServiceCollection().BuildServiceProvider());
+        var dataSources = new List<EndpointDataSource>();
+        endpoints.DataSources.Returns(dataSources);
+
+        var group = endpoints.MapDPIAEndpoints();
+
+        group.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void MapDPIAEndpoints_CustomPrefix_ReturnsRouteGroupBuilder()
+    {
+        var endpoints = Substitute.For<IEndpointRouteBuilder>();
+        endpoints.ServiceProvider.Returns(new ServiceCollection().BuildServiceProvider());
+        var dataSources = new List<EndpointDataSource>();
+        endpoints.DataSources.Returns(dataSources);
+
+        var group = endpoints.MapDPIAEndpoints("/compliance/dpia");
+
+        group.ShouldNotBeNull();
+    }
+
+    // ── Endpoint execution: GET /assessments ────────────────────────────────
+
+    [Fact]
+    public async Task GetAssessments_EmptyList_ReturnsOk()
+    {
+        var service = CreateService();
+        using var client = await CreateClientAsync(service);
+
+        using var response = await client.GetAsync(new Uri("/api/dpia/assessments", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetAssessments_PopulatedList_ReturnsOk()
+    {
+        var assessments = new List<DPIAReadModel>
+        {
+            new() { Id = Guid.NewGuid(), RequestTypeName = "MyApp.OrderCommand" }
+        };
+        var service = CreateService(all: assessments);
+        using var client = await CreateClientAsync(service);
+
+        using var response = await client.GetAsync(new Uri("/api/dpia/assessments", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    // ── Endpoint execution: GET /assessments/{id} ───────────────────────────
+
+    [Fact]
+    public async Task GetAssessmentById_NotFound_Returns404()
+    {
+        var service = CreateService(); // singleAssessment = null → returns NotFound error
+        using var client = await CreateClientAsync(service);
+
+        using var response = await client.GetAsync(
+            new Uri($"/api/dpia/assessments/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetAssessmentById_Found_Returns200()
+    {
+        var id = Guid.NewGuid();
+        var assessment = new DPIAReadModel { Id = id, RequestTypeName = "MyApp.OrderCommand" };
+        var service = CreateService(singleAssessment: assessment);
+        using var client = await CreateClientAsync(service);
+
+        using var response = await client.GetAsync(
+            new Uri($"/api/dpia/assessments/{id}", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    // ── Endpoint execution: POST /assessments/{id}/approve ──────────────────
+
+    [Fact]
+    public async Task Approve_Success_Returns200()
+    {
+        var service = CreateService();
+        using var client = await CreateClientAsync(service);
+
+        using var response = await client.PostAsync(
+            new Uri($"/api/dpia/assessments/{Guid.NewGuid()}/approve", UriKind.Relative),
+            content: null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Approve_NotFound_Returns404()
+    {
+        var service = CreateService(
+            approveResult: Left<EncinaError, Unit>(DPIAErrors.AssessmentNotFound(Guid.Empty)));
+        using var client = await CreateClientAsync(service);
+
+        using var response = await client.PostAsync(
+            new Uri($"/api/dpia/assessments/{Guid.NewGuid()}/approve", UriKind.Relative),
+            content: null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // ── Endpoint execution: POST /assessments/{id}/reject ───────────────────
+
+    [Fact]
+    public async Task Reject_Success_Returns200()
+    {
+        var service = CreateService();
+        using var client = await CreateClientAsync(service);
+
+        using var response = await client.PostAsJsonAsync(
+            new Uri($"/api/dpia/assessments/{Guid.NewGuid()}/reject", UriKind.Relative),
+            new RejectDPIARequest { Reason = "test" });
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Reject_NoBody_UsesDefaultReason_Returns200()
+    {
+        var service = CreateService();
+        using var client = await CreateClientAsync(service);
+
+        using var response = await client.PostAsync(
+            new Uri($"/api/dpia/assessments/{Guid.NewGuid()}/reject", UriKind.Relative),
+            content: null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Reject_NotFound_Returns404()
+    {
+        var service = CreateService(
+            rejectResult: Left<EncinaError, Unit>(DPIAErrors.AssessmentNotFound(Guid.Empty)));
+        using var client = await CreateClientAsync(service);
+
+        using var response = await client.PostAsync(
+            new Uri($"/api/dpia/assessments/{Guid.NewGuid()}/reject", UriKind.Relative),
+            content: null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    // ── Endpoint execution: GET /templates ──────────────────────────────────
+
+    [Fact]
+    public async Task GetTemplates_EmptyList_Returns200()
+    {
+        var service = CreateService();
+        using var client = await CreateClientAsync(service);
+
+        using var response = await client.GetAsync(new Uri("/api/dpia/templates", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    // ── Endpoint execution: GET /expired ────────────────────────────────────
+
+    [Fact]
+    public async Task GetExpired_EmptyList_Returns200()
+    {
+        var service = CreateService();
+        using var client = await CreateClientAsync(service);
+
+        using var response = await client.GetAsync(new Uri("/api/dpia/expired", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    // ── Endpoint execution: POST /assessments/{requestType}/assess ──────────
+
+    [Fact]
+    public async Task Assess_UnresolvableType_Returns400()
+    {
+        var service = CreateService();
+        using var client = await CreateClientAsync(service);
+
+        using var response = await client.PostAsync(
+            new Uri("/api/dpia/assessments/Some.NonExistent.Type/assess", UriKind.Relative),
+            content: null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+    }
+
+    // ── Custom prefix ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CustomPrefix_RoutesUnderNewPrefix()
+    {
+        var service = CreateService();
+        using var client = await CreateClientAsync(service, prefix: "/compliance/dpia");
+
+        using var response = await client.GetAsync(new Uri("/compliance/dpia/assessments", UriKind.Relative));
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+}

--- a/tests/Encina.UnitTests/AspNetCore/DPIAEndpointExtensionsTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/DPIAEndpointExtensionsTests.cs
@@ -16,8 +16,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using static LanguageExt.Prelude;
 
-#pragma warning disable CA2012 // Use ValueTasks correctly - Required for NSubstitute mocking
-
 namespace Encina.UnitTests.AspNetCore;
 
 /// <summary>
@@ -25,6 +23,21 @@ namespace Encina.UnitTests.AspNetCore;
 /// </summary>
 public sealed class DPIAEndpointExtensionsTests
 {
+    /// <summary>
+    /// Holds the started test host and its HTTP client so both are disposed together.
+    /// </summary>
+    private sealed class TestHarness(IHost host, HttpClient client) : IAsyncDisposable
+    {
+        public HttpClient Client { get; } = client;
+
+        public async ValueTask DisposeAsync()
+        {
+            Client.Dispose();
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
     private static IDPIAService CreateService(
         IReadOnlyList<DPIAReadModel>? all = null,
         IReadOnlyList<DPIAReadModel>? expired = null,
@@ -34,6 +47,7 @@ public sealed class DPIAEndpointExtensionsTests
     {
         var service = Substitute.For<IDPIAService>();
 
+#pragma warning disable CA2012 // Use ValueTasks correctly - Required for NSubstitute mocking
         service.GetAllAssessmentsAsync(Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult<Either<EncinaError, IReadOnlyList<DPIAReadModel>>>(
                 Right<EncinaError, IReadOnlyList<DPIAReadModel>>(all ?? [])));
@@ -64,6 +78,7 @@ public sealed class DPIAEndpointExtensionsTests
                 Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult(rejectResult
                 ?? Right<EncinaError, Unit>(Unit.Default)));
+#pragma warning restore CA2012
 
         return service;
     }
@@ -72,13 +87,15 @@ public sealed class DPIAEndpointExtensionsTests
         IReadOnlyList<DPIATemplate>? templates = null)
     {
         var provider = Substitute.For<IDPIATemplateProvider>();
+#pragma warning disable CA2012 // Use ValueTasks correctly - Required for NSubstitute mocking
         provider.GetAllTemplatesAsync(Arg.Any<CancellationToken>())
             .Returns(ValueTask.FromResult<Either<EncinaError, IReadOnlyList<DPIATemplate>>>(
                 Right<EncinaError, IReadOnlyList<DPIATemplate>>(templates ?? [])));
+#pragma warning restore CA2012
         return provider;
     }
 
-    private static async Task<HttpClient> CreateClientAsync(
+    private static async Task<TestHarness> CreateHarnessAsync(
         IDPIAService service,
         IDPIATemplateProvider? templateProvider = null,
         string prefix = "/api/dpia")
@@ -108,7 +125,7 @@ public sealed class DPIAEndpointExtensionsTests
             });
 
         var host = await builder.StartAsync();
-        return host.GetTestClient();
+        return new TestHarness(host, host.GetTestClient());
     }
 
     // ── DTO defaults ────────────────────────────────────────────────────────
@@ -200,9 +217,9 @@ public sealed class DPIAEndpointExtensionsTests
     public async Task GetAssessments_EmptyList_ReturnsOk()
     {
         var service = CreateService();
-        using var client = await CreateClientAsync(service);
+        await using var harness = await CreateHarnessAsync(service);
 
-        using var response = await client.GetAsync(new Uri("/api/dpia/assessments", UriKind.Relative));
+        using var response = await harness.Client.GetAsync(new Uri("/api/dpia/assessments", UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
@@ -215,9 +232,9 @@ public sealed class DPIAEndpointExtensionsTests
             new() { Id = Guid.NewGuid(), RequestTypeName = "MyApp.OrderCommand" }
         };
         var service = CreateService(all: assessments);
-        using var client = await CreateClientAsync(service);
+        await using var harness = await CreateHarnessAsync(service);
 
-        using var response = await client.GetAsync(new Uri("/api/dpia/assessments", UriKind.Relative));
+        using var response = await harness.Client.GetAsync(new Uri("/api/dpia/assessments", UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
@@ -228,9 +245,9 @@ public sealed class DPIAEndpointExtensionsTests
     public async Task GetAssessmentById_NotFound_Returns404()
     {
         var service = CreateService(); // singleAssessment = null → returns NotFound error
-        using var client = await CreateClientAsync(service);
+        await using var harness = await CreateHarnessAsync(service);
 
-        using var response = await client.GetAsync(
+        using var response = await harness.Client.GetAsync(
             new Uri($"/api/dpia/assessments/{Guid.NewGuid()}", UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
@@ -242,9 +259,9 @@ public sealed class DPIAEndpointExtensionsTests
         var id = Guid.NewGuid();
         var assessment = new DPIAReadModel { Id = id, RequestTypeName = "MyApp.OrderCommand" };
         var service = CreateService(singleAssessment: assessment);
-        using var client = await CreateClientAsync(service);
+        await using var harness = await CreateHarnessAsync(service);
 
-        using var response = await client.GetAsync(
+        using var response = await harness.Client.GetAsync(
             new Uri($"/api/dpia/assessments/{id}", UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -256,9 +273,9 @@ public sealed class DPIAEndpointExtensionsTests
     public async Task Approve_Success_Returns200()
     {
         var service = CreateService();
-        using var client = await CreateClientAsync(service);
+        await using var harness = await CreateHarnessAsync(service);
 
-        using var response = await client.PostAsync(
+        using var response = await harness.Client.PostAsync(
             new Uri($"/api/dpia/assessments/{Guid.NewGuid()}/approve", UriKind.Relative),
             content: null);
 
@@ -270,9 +287,9 @@ public sealed class DPIAEndpointExtensionsTests
     {
         var service = CreateService(
             approveResult: Left<EncinaError, Unit>(DPIAErrors.AssessmentNotFound(Guid.Empty)));
-        using var client = await CreateClientAsync(service);
+        await using var harness = await CreateHarnessAsync(service);
 
-        using var response = await client.PostAsync(
+        using var response = await harness.Client.PostAsync(
             new Uri($"/api/dpia/assessments/{Guid.NewGuid()}/approve", UriKind.Relative),
             content: null);
 
@@ -285,9 +302,9 @@ public sealed class DPIAEndpointExtensionsTests
     public async Task Reject_Success_Returns200()
     {
         var service = CreateService();
-        using var client = await CreateClientAsync(service);
+        await using var harness = await CreateHarnessAsync(service);
 
-        using var response = await client.PostAsJsonAsync(
+        using var response = await harness.Client.PostAsJsonAsync(
             new Uri($"/api/dpia/assessments/{Guid.NewGuid()}/reject", UriKind.Relative),
             new RejectDPIARequest { Reason = "test" });
 
@@ -298,9 +315,9 @@ public sealed class DPIAEndpointExtensionsTests
     public async Task Reject_NoBody_UsesDefaultReason_Returns200()
     {
         var service = CreateService();
-        using var client = await CreateClientAsync(service);
+        await using var harness = await CreateHarnessAsync(service);
 
-        using var response = await client.PostAsync(
+        using var response = await harness.Client.PostAsync(
             new Uri($"/api/dpia/assessments/{Guid.NewGuid()}/reject", UriKind.Relative),
             content: null);
 
@@ -312,9 +329,9 @@ public sealed class DPIAEndpointExtensionsTests
     {
         var service = CreateService(
             rejectResult: Left<EncinaError, Unit>(DPIAErrors.AssessmentNotFound(Guid.Empty)));
-        using var client = await CreateClientAsync(service);
+        await using var harness = await CreateHarnessAsync(service);
 
-        using var response = await client.PostAsync(
+        using var response = await harness.Client.PostAsync(
             new Uri($"/api/dpia/assessments/{Guid.NewGuid()}/reject", UriKind.Relative),
             content: null);
 
@@ -327,9 +344,9 @@ public sealed class DPIAEndpointExtensionsTests
     public async Task GetTemplates_EmptyList_Returns200()
     {
         var service = CreateService();
-        using var client = await CreateClientAsync(service);
+        await using var harness = await CreateHarnessAsync(service);
 
-        using var response = await client.GetAsync(new Uri("/api/dpia/templates", UriKind.Relative));
+        using var response = await harness.Client.GetAsync(new Uri("/api/dpia/templates", UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
@@ -340,9 +357,9 @@ public sealed class DPIAEndpointExtensionsTests
     public async Task GetExpired_EmptyList_Returns200()
     {
         var service = CreateService();
-        using var client = await CreateClientAsync(service);
+        await using var harness = await CreateHarnessAsync(service);
 
-        using var response = await client.GetAsync(new Uri("/api/dpia/expired", UriKind.Relative));
+        using var response = await harness.Client.GetAsync(new Uri("/api/dpia/expired", UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }
@@ -353,9 +370,9 @@ public sealed class DPIAEndpointExtensionsTests
     public async Task Assess_UnresolvableType_Returns400()
     {
         var service = CreateService();
-        using var client = await CreateClientAsync(service);
+        await using var harness = await CreateHarnessAsync(service);
 
-        using var response = await client.PostAsync(
+        using var response = await harness.Client.PostAsync(
             new Uri("/api/dpia/assessments/Some.NonExistent.Type/assess", UriKind.Relative),
             content: null);
 
@@ -368,9 +385,9 @@ public sealed class DPIAEndpointExtensionsTests
     public async Task CustomPrefix_RoutesUnderNewPrefix()
     {
         var service = CreateService();
-        using var client = await CreateClientAsync(service, prefix: "/compliance/dpia");
+        await using var harness = await CreateHarnessAsync(service, prefix: "/compliance/dpia");
 
-        using var response = await client.GetAsync(new Uri("/compliance/dpia/assessments", UriKind.Relative));
+        using var response = await harness.Client.GetAsync(new Uri("/compliance/dpia/assessments", UriKind.Relative));
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
     }

--- a/tests/Encina.UnitTests/AspNetCore/HttpRegionContextProviderTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/HttpRegionContextProviderTests.cs
@@ -100,7 +100,7 @@ public sealed class HttpRegionContextProviderTests
     }
 
     [Fact]
-    public async Task GetCurrentRegionAsync_HeaderWhitespaceTrimmed()
+    public async Task GetCurrentRegionAsync_HeaderWithWhitespace_ReturnsTrimmedRegionCode()
     {
         var http = new DefaultHttpContext();
         http.Request.Headers["X-Data-Region"] = "  DE  ";

--- a/tests/Encina.UnitTests/AspNetCore/HttpRegionContextProviderTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/HttpRegionContextProviderTests.cs
@@ -1,0 +1,198 @@
+using Encina.AspNetCore;
+using Encina.Compliance.DataResidency;
+using Encina.Compliance.DataResidency.Model;
+using LanguageExt;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Encina.UnitTests.AspNetCore;
+
+/// <summary>
+/// Unit tests for <see cref="HttpRegionContextProvider"/>.
+/// </summary>
+public sealed class HttpRegionContextProviderTests
+{
+    private static HttpRegionContextProvider CreateProvider(
+        HttpContext? httpContext = null,
+        DataResidencyOptions? residency = null,
+        EncinaAspNetCoreOptions? aspNetOptions = null)
+    {
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(httpContext);
+
+        return new HttpRegionContextProvider(
+            accessor,
+            Options.Create(residency ?? new DataResidencyOptions()),
+            Options.Create(aspNetOptions ?? new EncinaAspNetCoreOptions()),
+            NullLogger<HttpRegionContextProvider>.Instance);
+    }
+
+    [Fact]
+    public async Task GetCurrentRegionAsync_HeaderPresent_KnownRegion_ReturnsRegistryRegion()
+    {
+        var http = new DefaultHttpContext();
+        http.Request.Headers["X-Data-Region"] = "DE";
+        var provider = CreateProvider(http);
+
+        var result = await provider.GetCurrentRegionAsync();
+
+        result.IsRight.ShouldBeTrue();
+        result.Match(
+            Right: r =>
+            {
+                r.Code.ShouldBe("DE");
+                r.IsEU.ShouldBeTrue();
+            },
+            Left: _ => throw new Xunit.Sdk.XunitException("Expected Right"));
+    }
+
+    [Fact]
+    public async Task GetCurrentRegionAsync_HeaderPresent_KnownRegion_LowerCase_ReturnsRegistryRegion()
+    {
+        var http = new DefaultHttpContext();
+        http.Request.Headers["X-Data-Region"] = "de";
+        var provider = CreateProvider(http);
+
+        var result = await provider.GetCurrentRegionAsync();
+
+        result.IsRight.ShouldBeTrue();
+        result.Match(
+            Right: r => r.Code.ShouldBe("DE"),
+            Left: _ => throw new Xunit.Sdk.XunitException("Expected Right"));
+    }
+
+    [Fact]
+    public async Task GetCurrentRegionAsync_HeaderPresent_UnknownRegion_ReturnsCustomRegion()
+    {
+        var http = new DefaultHttpContext();
+        http.Request.Headers["X-Data-Region"] = "AZURE-WESTEU";
+        var provider = CreateProvider(http);
+
+        var result = await provider.GetCurrentRegionAsync();
+
+        result.IsRight.ShouldBeTrue();
+        result.Match(
+            Right: r =>
+            {
+                r.Code.ShouldBe("AZURE-WESTEU");
+                r.ProtectionLevel.ShouldBe(DataProtectionLevel.Unknown);
+            },
+            Left: _ => throw new Xunit.Sdk.XunitException("Expected Right"));
+    }
+
+    [Fact]
+    public async Task GetCurrentRegionAsync_HeaderPresent_TwoLetterUnknown_UsesCodeAsCountry()
+    {
+        var http = new DefaultHttpContext();
+        http.Request.Headers["X-Data-Region"] = "ZZ";
+        var provider = CreateProvider(http);
+
+        var result = await provider.GetCurrentRegionAsync();
+
+        result.IsRight.ShouldBeTrue();
+        result.Match(
+            Right: r =>
+            {
+                r.Code.ShouldBe("ZZ");
+                r.Country.ShouldBe("ZZ");
+            },
+            Left: _ => throw new Xunit.Sdk.XunitException("Expected Right"));
+    }
+
+    [Fact]
+    public async Task GetCurrentRegionAsync_HeaderWhitespaceTrimmed()
+    {
+        var http = new DefaultHttpContext();
+        http.Request.Headers["X-Data-Region"] = "  DE  ";
+        var provider = CreateProvider(http);
+
+        var result = await provider.GetCurrentRegionAsync();
+
+        result.IsRight.ShouldBeTrue();
+        result.Match(
+            Right: r => r.Code.ShouldBe("DE"),
+            Left: _ => throw new Xunit.Sdk.XunitException("Expected Right"));
+    }
+
+    [Fact]
+    public async Task GetCurrentRegionAsync_HeaderEmpty_FallsBackToDefault()
+    {
+        var http = new DefaultHttpContext();
+        http.Request.Headers["X-Data-Region"] = "";
+        var provider = CreateProvider(http, new DataResidencyOptions { DefaultRegion = RegionRegistry.US });
+
+        var result = await provider.GetCurrentRegionAsync();
+
+        result.IsRight.ShouldBeTrue();
+        result.Match(
+            Right: r => r.Code.ShouldBe("US"),
+            Left: _ => throw new Xunit.Sdk.XunitException("Expected Right"));
+    }
+
+    [Fact]
+    public async Task GetCurrentRegionAsync_NoHeader_FallsBackToDefault()
+    {
+        var http = new DefaultHttpContext();
+        var provider = CreateProvider(http, new DataResidencyOptions { DefaultRegion = RegionRegistry.FR });
+
+        var result = await provider.GetCurrentRegionAsync();
+
+        result.IsRight.ShouldBeTrue();
+        result.Match(
+            Right: r => r.Code.ShouldBe("FR"),
+            Left: _ => throw new Xunit.Sdk.XunitException("Expected Right"));
+    }
+
+    [Fact]
+    public async Task GetCurrentRegionAsync_NoHttpContext_FallsBackToDefault()
+    {
+        var provider = CreateProvider(httpContext: null,
+            residency: new DataResidencyOptions { DefaultRegion = RegionRegistry.JP });
+
+        var result = await provider.GetCurrentRegionAsync();
+
+        result.IsRight.ShouldBeTrue();
+        result.Match(
+            Right: r => r.Code.ShouldBe("JP"),
+            Left: _ => throw new Xunit.Sdk.XunitException("Expected Right"));
+    }
+
+    [Fact]
+    public async Task GetCurrentRegionAsync_NoHeaderNoDefault_ReturnsLeftError()
+    {
+        var http = new DefaultHttpContext();
+        var provider = CreateProvider(http, new DataResidencyOptions { DefaultRegion = null });
+
+        var result = await provider.GetCurrentRegionAsync();
+
+        result.IsLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetCurrentRegionAsync_NoHttpContextNoDefault_ReturnsLeftError()
+    {
+        var provider = CreateProvider(httpContext: null,
+            residency: new DataResidencyOptions { DefaultRegion = null });
+
+        var result = await provider.GetCurrentRegionAsync();
+
+        result.IsLeft.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetCurrentRegionAsync_CustomHeaderName_ReadsFromCustomHeader()
+    {
+        var http = new DefaultHttpContext();
+        http.Request.Headers["X-My-Region"] = "ES";
+        var provider = CreateProvider(
+            http,
+            aspNetOptions: new EncinaAspNetCoreOptions { DataRegionHeaderName = "X-My-Region" });
+
+        var result = await provider.GetCurrentRegionAsync();
+
+        result.IsRight.ShouldBeTrue();
+        result.Match(
+            Right: r => r.Code.ShouldBe("ES"),
+            Left: _ => throw new Xunit.Sdk.XunitException("Expected Right"));
+    }
+}

--- a/tests/Encina.UnitTests/AspNetCore/ServiceCollectionExtensionsTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/ServiceCollectionExtensionsTests.cs
@@ -160,6 +160,7 @@ public sealed class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddRouting();
 
         services.AddEncinaAuthorization();
         using var provider = BuildValidatedProvider(services);
@@ -174,6 +175,7 @@ public sealed class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddRouting();
 
         services.AddEncinaAuthorization();
         using var provider = BuildValidatedProvider(services);
@@ -198,6 +200,7 @@ public sealed class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddRouting();
 
         services.AddEncinaAuthorization();
         using var provider = BuildValidatedProvider(services);
@@ -213,6 +216,7 @@ public sealed class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddRouting();
 
         services.AddEncinaAuthorization(
             configurePolicies: policies =>

--- a/tests/Encina.UnitTests/AspNetCore/ServiceCollectionExtensionsTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/ServiceCollectionExtensionsTests.cs
@@ -195,8 +195,8 @@ public sealed class ServiceCollectionExtensionsTests
 
         var config = provider.GetRequiredService<IOptions<AuthorizationConfiguration>>().Value;
         config.AutoApplyPolicies.ShouldBeFalse();
-        config.DefaultCommandPolicy.ShouldBe("RequireAuthenticated");
-        config.DefaultQueryPolicy.ShouldBe("RequireAuthenticated");
+        config.DefaultCommandPolicy.ShouldBe(AuthorizationConfiguration.RequireAuthenticatedPolicyName);
+        config.DefaultQueryPolicy.ShouldBe(AuthorizationConfiguration.RequireAuthenticatedPolicyName);
     }
 
     [Fact]

--- a/tests/Encina.UnitTests/AspNetCore/ServiceCollectionExtensionsTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,219 @@
+using Encina.AspNetCore;
+using Encina.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Encina.UnitTests.AspNetCore;
+
+/// <summary>
+/// Unit tests for <see cref="ServiceCollectionExtensions"/>.
+/// </summary>
+public sealed class ServiceCollectionExtensionsTests
+{
+    // ── AddEncinaAspNetCore (parameterless overload) ───────────────────────
+
+    [Fact]
+    public void AddEncinaAspNetCore_RegistersRequestContextAccessor()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddEncinaAspNetCore();
+        using var provider = services.BuildServiceProvider();
+
+        var accessor = provider.GetService<IRequestContextAccessor>();
+        accessor.ShouldNotBeNull();
+        accessor.ShouldBeOfType<RequestContextAccessor>();
+    }
+
+    [Fact]
+    public void AddEncinaAspNetCore_RegistersHttpContextAccessor()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddEncinaAspNetCore();
+        using var provider = services.BuildServiceProvider();
+
+        var http = provider.GetService<IHttpContextAccessor>();
+        http.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddEncinaAspNetCore_RegistersOptions_WithDefaultValues()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddEncinaAspNetCore();
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<EncinaAspNetCoreOptions>>().Value;
+        options.CorrelationIdHeader.ShouldBe("X-Correlation-ID");
+        options.TenantIdHeader.ShouldBe("X-Tenant-ID");
+        options.IdempotencyKeyHeader.ShouldBe("X-Idempotency-Key");
+    }
+
+    [Fact]
+    public void AddEncinaAspNetCore_ReturnsSameServiceCollection_ForChaining()
+    {
+        var services = new ServiceCollection();
+
+        var result = services.AddEncinaAspNetCore();
+
+        result.ShouldBeSameAs(services);
+    }
+
+    [Fact]
+    public void AddEncinaAspNetCore_RequestContextAccessor_RegisteredAsSingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddEncinaAspNetCore();
+
+        var descriptor = services.Single(s => s.ServiceType == typeof(IRequestContextAccessor));
+
+        descriptor.Lifetime.ShouldBe(ServiceLifetime.Singleton);
+    }
+
+    // ── AddEncinaAspNetCore (configure overload) ───────────────────────────
+
+    [Fact]
+    public void AddEncinaAspNetCore_WithConfigureOptions_AppliesCustomValues()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddEncinaAspNetCore(o =>
+        {
+            o.CorrelationIdHeader = "X-Custom-Correlation";
+            o.TenantIdHeader = "X-Custom-Tenant";
+            o.IdempotencyKeyHeader = "X-Custom-Idempotency";
+            o.UserIdClaimType = "sub";
+            o.TenantIdClaimType = "tid";
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var options = provider.GetRequiredService<IOptions<EncinaAspNetCoreOptions>>().Value;
+        options.CorrelationIdHeader.ShouldBe("X-Custom-Correlation");
+        options.TenantIdHeader.ShouldBe("X-Custom-Tenant");
+        options.IdempotencyKeyHeader.ShouldBe("X-Custom-Idempotency");
+        options.UserIdClaimType.ShouldBe("sub");
+        options.TenantIdClaimType.ShouldBe("tid");
+    }
+
+    [Fact]
+    public void AddEncinaAspNetCore_CalledTwice_DoesNotRegisterDuplicateAccessor()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddEncinaAspNetCore();
+        services.AddEncinaAspNetCore();
+
+        var descriptors = services.Where(s => s.ServiceType == typeof(IRequestContextAccessor)).ToList();
+        descriptors.Count.ShouldBe(1);
+    }
+
+    // ── AddAuthorization (EncinaConfiguration extension) ───────────────────
+
+    [Fact]
+    public void AddAuthorization_AddsAuthorizationPipelineBehavior()
+    {
+        var configuration = new EncinaConfiguration();
+
+        var result = configuration.AddAuthorization();
+
+        result.ShouldBeSameAs(configuration);
+        configuration.PipelineBehaviorTypes.ShouldContain(typeof(AuthorizationPipelineBehavior<,>));
+    }
+
+    [Fact]
+    public void AddAuthorization_CalledTwice_DoesNotDuplicateBehavior()
+    {
+        // EncinaConfiguration.AddPipelineBehavior deduplicates registrations.
+        var configuration = new EncinaConfiguration();
+
+        configuration.AddAuthorization();
+        configuration.AddAuthorization();
+
+        configuration.PipelineBehaviorTypes
+            .Count(t => t == typeof(AuthorizationPipelineBehavior<,>))
+            .ShouldBe(1);
+    }
+
+    // ── AddEncinaAuthorization registers RequireAuthenticated policy ───────
+
+    [Fact]
+    public void AddEncinaAuthorization_RegistersRequireAuthenticatedPolicy()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddEncinaAuthorization();
+        using var provider = services.BuildServiceProvider();
+
+        var authOptions = provider.GetRequiredService<IOptions<AuthorizationOptions>>().Value;
+        var policy = authOptions.GetPolicy(AuthorizationConfiguration.RequireAuthenticatedPolicyName);
+        policy.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddEncinaAuthorization_RegistersHttpContextAccessor()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddEncinaAuthorization();
+        using var provider = services.BuildServiceProvider();
+
+        var http = provider.GetService<IHttpContextAccessor>();
+        http.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddEncinaAuthorization_ReturnsSameServiceCollection_ForChaining()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var result = services.AddEncinaAuthorization();
+
+        result.ShouldBeSameAs(services);
+    }
+
+    [Fact]
+    public void AddEncinaAuthorization_WithoutCallbacks_UsesDefaults()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddEncinaAuthorization();
+        using var provider = services.BuildServiceProvider();
+
+        var config = provider.GetRequiredService<IOptions<AuthorizationConfiguration>>().Value;
+        config.AutoApplyPolicies.ShouldBeFalse();
+        config.DefaultCommandPolicy.ShouldBe("RequireAuthenticated");
+        config.DefaultQueryPolicy.ShouldBe("RequireAuthenticated");
+    }
+
+    [Fact]
+    public void AddEncinaAuthorization_PoliciesCallback_RegistersPolicy()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddEncinaAuthorization(
+            configurePolicies: policies =>
+            {
+                policies.AddPolicy("CustomTest", p => p.RequireAuthenticatedUser());
+            });
+
+        using var provider = services.BuildServiceProvider();
+        var authOptions = provider.GetRequiredService<IOptions<AuthorizationOptions>>().Value;
+        var policy = authOptions.GetPolicy("CustomTest");
+        policy.ShouldNotBeNull();
+    }
+}

--- a/tests/Encina.UnitTests/AspNetCore/ServiceCollectionExtensionsTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/ServiceCollectionExtensionsTests.cs
@@ -15,7 +15,7 @@ public sealed class ServiceCollectionExtensionsTests
     // ── AddEncinaAspNetCore (parameterless overload) ───────────────────────
 
     [Fact]
-    public void AddEncinaAspNetCore_RegistersRequestContextAccessor()
+    public void AddEncinaAspNetCore_WhenCalled_RegistersRequestContextAccessor()
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -29,7 +29,7 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddEncinaAspNetCore_RegistersHttpContextAccessor()
+    public void AddEncinaAspNetCore_WhenCalled_RegistersHttpContextAccessor()
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -120,7 +120,7 @@ public sealed class ServiceCollectionExtensionsTests
     // ── AddAuthorization (EncinaConfiguration extension) ───────────────────
 
     [Fact]
-    public void AddAuthorization_AddsAuthorizationPipelineBehavior()
+    public void AddAuthorization_WhenCalled_AddsAuthorizationPipelineBehavior()
     {
         var configuration = new EncinaConfiguration();
 
@@ -147,7 +147,7 @@ public sealed class ServiceCollectionExtensionsTests
     // ── AddEncinaAuthorization registers RequireAuthenticated policy ───────
 
     [Fact]
-    public void AddEncinaAuthorization_RegistersRequireAuthenticatedPolicy()
+    public void AddEncinaAuthorization_WhenCalled_RegistersRequireAuthenticatedPolicy()
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -161,7 +161,7 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddEncinaAuthorization_RegistersHttpContextAccessor()
+    public void AddEncinaAuthorization_WhenCalled_RegistersHttpContextAccessor()
     {
         var services = new ServiceCollection();
         services.AddLogging();

--- a/tests/Encina.UnitTests/AspNetCore/ServiceCollectionExtensionsTests.cs
+++ b/tests/Encina.UnitTests/AspNetCore/ServiceCollectionExtensionsTests.cs
@@ -12,6 +12,15 @@ namespace Encina.UnitTests.AspNetCore;
 /// </summary>
 public sealed class ServiceCollectionExtensionsTests
 {
+    private static readonly ServiceProviderOptions ValidatedProviderOptions = new()
+    {
+        ValidateOnBuild = true,
+        ValidateScopes = true,
+    };
+
+    private static ServiceProvider BuildValidatedProvider(IServiceCollection services) =>
+        services.BuildServiceProvider(ValidatedProviderOptions);
+
     // ── AddEncinaAspNetCore (parameterless overload) ───────────────────────
 
     [Fact]
@@ -21,7 +30,7 @@ public sealed class ServiceCollectionExtensionsTests
         services.AddLogging();
 
         services.AddEncinaAspNetCore();
-        using var provider = services.BuildServiceProvider();
+        using var provider = BuildValidatedProvider(services);
 
         var accessor = provider.GetService<IRequestContextAccessor>();
         accessor.ShouldNotBeNull();
@@ -35,7 +44,7 @@ public sealed class ServiceCollectionExtensionsTests
         services.AddLogging();
 
         services.AddEncinaAspNetCore();
-        using var provider = services.BuildServiceProvider();
+        using var provider = BuildValidatedProvider(services);
 
         var http = provider.GetService<IHttpContextAccessor>();
         http.ShouldNotBeNull();
@@ -48,7 +57,7 @@ public sealed class ServiceCollectionExtensionsTests
         services.AddLogging();
 
         services.AddEncinaAspNetCore();
-        using var provider = services.BuildServiceProvider();
+        using var provider = BuildValidatedProvider(services);
 
         var options = provider.GetRequiredService<IOptions<EncinaAspNetCoreOptions>>().Value;
         options.CorrelationIdHeader.ShouldBe("X-Correlation-ID");
@@ -94,7 +103,7 @@ public sealed class ServiceCollectionExtensionsTests
             o.UserIdClaimType = "sub";
             o.TenantIdClaimType = "tid";
         });
-        using var provider = services.BuildServiceProvider();
+        using var provider = BuildValidatedProvider(services);
 
         var options = provider.GetRequiredService<IOptions<EncinaAspNetCoreOptions>>().Value;
         options.CorrelationIdHeader.ShouldBe("X-Custom-Correlation");
@@ -153,7 +162,7 @@ public sealed class ServiceCollectionExtensionsTests
         services.AddLogging();
 
         services.AddEncinaAuthorization();
-        using var provider = services.BuildServiceProvider();
+        using var provider = BuildValidatedProvider(services);
 
         var authOptions = provider.GetRequiredService<IOptions<AuthorizationOptions>>().Value;
         var policy = authOptions.GetPolicy(AuthorizationConfiguration.RequireAuthenticatedPolicyName);
@@ -167,7 +176,7 @@ public sealed class ServiceCollectionExtensionsTests
         services.AddLogging();
 
         services.AddEncinaAuthorization();
-        using var provider = services.BuildServiceProvider();
+        using var provider = BuildValidatedProvider(services);
 
         var http = provider.GetService<IHttpContextAccessor>();
         http.ShouldNotBeNull();
@@ -191,7 +200,7 @@ public sealed class ServiceCollectionExtensionsTests
         services.AddLogging();
 
         services.AddEncinaAuthorization();
-        using var provider = services.BuildServiceProvider();
+        using var provider = BuildValidatedProvider(services);
 
         var config = provider.GetRequiredService<IOptions<AuthorizationConfiguration>>().Value;
         config.AutoApplyPolicies.ShouldBeFalse();
@@ -211,7 +220,7 @@ public sealed class ServiceCollectionExtensionsTests
                 policies.AddPolicy("CustomTest", p => p.RequireAuthenticatedUser());
             });
 
-        using var provider = services.BuildServiceProvider();
+        using var provider = BuildValidatedProvider(services);
         var authOptions = provider.GetRequiredService<IOptions<AuthorizationOptions>>().Value;
         var policy = authOptions.GetPolicy("CustomTest");
         policy.ShouldNotBeNull();


### PR DESCRIPTION
## Summary
- Adds unit tests for previously uncovered files in `Encina.AspNetCore`:
  - `ApplicationBuilderExtensions.UseEncinaContext`
  - `ServiceCollectionExtensions.AddEncinaAspNetCore` / `AddAuthorization` / `AddEncinaAuthorization`
  - `HttpRegionContextProvider` (header parsing, defaults, missing context)
  - `DPIAEndpointExtensions` (TestServer-driven endpoint paths + DTOs + constants)
- All 234 AspNetCore unit tests pass locally; total +45 new tests across 4 files.
- Targets the `unit` flag for `Encina.AspNetCore` (manifest target: 60%).

## Test plan
- [x] `dotnet build tests/Encina.UnitTests/Encina.UnitTests.csproj -c Release` succeeds with 0 warnings
- [x] `dotnet test --filter "FullyQualifiedName~Encina.UnitTests.AspNetCore"` passes (234/234)
- [ ] CI Full to validate per-flag coverage on dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Versión

* **Tests**
  * Ampliada la cobertura de pruebas ASP.NET Core: validación de UseEncinaContext y construcción de pipeline, tests de registro/ejecución de endpoints DPIA con comprobaciones de rutas y códigos HTTP, y pruebas del proveedor de contexto regional con manejo de cabeceras, valores por defecto y casos de error.
  * Nuevas pruebas para extensiones de colección de servicios y autorización, comprobando registros, opciones por defecto y comportamiento idempotente.

* **Chores**
  * Añadida dependencia de System.Security.Cryptography.Xml para el proyecto de pruebas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->