### PR TITLE
fix(docs): API Reference aux_link baseurl + namespace dropdown scroll

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,8 +10,13 @@ url: https://dlrivada.github.io
 baseurl: /Encina
 
 aux_links:
+  # just-the-docs does NOT apply relative_url/baseurl to aux_links targets
+  # (contrary to common assumptions — verified by observing the rendered HTML
+  # which emits href="/api/" verbatim). The absolute path MUST include the
+  # baseurl explicitly, otherwise clicking the link goes to
+  # https://dlrivada.github.io/api/ (404) instead of .../Encina/api/.
   "API Reference":
-    - /api/
+    - /Encina/api/
   "GitHub":
     - https://github.com/dlrivada/Encina
 

--- a/docs/_docfx-template/public/main.css
+++ b/docs/_docfx-template/public/main.css
@@ -5,25 +5,18 @@
  */
 
 /*
- * Namespace dropdown in the header.
+ * Namespace dropdown in the header only.
  *
  * DocFX modern builds the namespace switcher as a Bootstrap 5 dropdown from
  * the TOC. With a large library (Encina has ~110 public namespaces) the
  * rendered menu overflows the viewport and there's no way to scroll to
  * items near the end. Constrain the height and enable inner scroll.
+ *
+ * Scoped to `header .navbar` to avoid affecting other Bootstrap dropdowns
+ * on the site (e.g. autocomplete/typeahead menus rendered elsewhere).
  */
-.navbar .dropdown-menu,
-.dropdown-menu {
+header .navbar .dropdown-menu {
   max-height: 80vh;
   overflow-y: auto;
   overflow-x: hidden;
-}
-
-/*
- * Left-sidebar TOC: also benefits from a scrollable container when the
- * list is long. The modern template already does this via flex layout,
- * but ensure sane behavior at small viewport heights too.
- */
-.toc {
-  scroll-behavior: smooth;
 }

--- a/docs/_docfx-template/public/main.css
+++ b/docs/_docfx-template/public/main.css
@@ -1,0 +1,29 @@
+/*
+ * Custom overrides on top of DocFX modern template.
+ * This file replaces the empty main.css shipped by the modern template
+ * (via the template chain in docfx.json).
+ */
+
+/*
+ * Namespace dropdown in the header.
+ *
+ * DocFX modern builds the namespace switcher as a Bootstrap 5 dropdown from
+ * the TOC. With a large library (Encina has ~110 public namespaces) the
+ * rendered menu overflows the viewport and there's no way to scroll to
+ * items near the end. Constrain the height and enable inner scroll.
+ */
+.navbar .dropdown-menu,
+.dropdown-menu {
+  max-height: 80vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/*
+ * Left-sidebar TOC: also benefits from a scrollable container when the
+ * list is long. The modern template already does this via flex layout,
+ * but ensure sane behavior at small viewport heights too.
+ */
+.toc {
+  scroll-behavior: smooth;
+}

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -44,7 +44,8 @@
     "output": "_api-build",
     "template": [
       "default",
-      "modern"
+      "modern",
+      "_docfx-template"
     ],
     "globalMetadata": {
       "_appName": "Encina",


### PR DESCRIPTION
Two post-#1031 UX regressions in the live Pages site at https://dlrivada.github.io/Encina/.

## Fix 1 — `aux_link` baseurl missing

Navbar 'API Reference' button links to `/api/` → 404 at `https://dlrivada.github.io/api/`. Should be `/Encina/api/`.

**Root cause**: In [PR #1031](https://github.com/dlrivada/Encina/pull/1031), a Copilot review comment claimed just-the-docs applies `relative_url` to `aux_links` targets (prepending `baseurl` automatically). Changed the config to `/api/` based on that reasoning. Wrong — verified by inspecting the live rendered HTML:

```html
<a href="/api/" class="site-button" target="_blank" rel="noopener noreferrer">API Reference</a>
```

The path is emitted verbatim. Reverted to `/Encina/api/` + comment in `_config.yml`.

## Fix 2 — namespace dropdown overflows viewport

The 'Encina ▾' header selector in the DocFX API site is built from TOC at runtime. With ~110 public namespaces the rendered dropdown runs off the bottom of the viewport — items after ~row 40 are unreachable (no inner scroll).

Added a custom template layer `docs/_docfx-template/public/main.css` that replaces modern template's empty placeholder `main.css`. Constrains `.dropdown-menu` to `max-height: 80vh` + `overflow-y: auto`.

**Verified locally**:
- Computed `max-height: 1001.6px` (= 80vh at 1252px viewport) ✓
- Computed `overflow-y: auto` ✓
- Dropdown contains 98 namespace items ✓

## Test plan

- [ ] Click 'API Reference' on `https://dlrivada.github.io/Encina/` → lands on `.../Encina/api/` (DocFX landing)
- [ ] On any `/Encina/api/*` page, click the 'Encina ▾' dropdown → scrolls to reach the last namespace

## Refs

- Closes regressions in #1031 (#91)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Documentación**
  * Se corrigió la navegación del enlace de referencia de API para resolver correctamente en la ruta base del sitio.
  * Se mejoró la experiencia del menú desplegable de espacios de nombres con altura limitada y desplazamiento vertical automático.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->