### PR TITLE
fix(messaging): async Open/BeginTransaction in TransactionPipelineBehavior

### DIFF
--- a/src/Encina.Messaging/TransactionPipelineBehavior.cs
+++ b/src/Encina.Messaging/TransactionPipelineBehavior.cs
@@ -77,7 +77,7 @@ public sealed class TransactionPipelineBehavior<TRequest, TResponse> : IPipeline
 
         try
         {
-            var result = await nextStep();
+            var result = await nextStep().ConfigureAwait(false);
 
             await result.Match(
                 Right: _ => CommitAsync(transaction, cancellationToken),

--- a/src/Encina.Messaging/TransactionPipelineBehavior.cs
+++ b/src/Encina.Messaging/TransactionPipelineBehavior.cs
@@ -19,6 +19,11 @@ namespace Encina.Messaging;
 /// <para>
 /// The connection is opened automatically if it's not already open.
 /// </para>
+/// <para>
+/// The caller's <see cref="CancellationToken"/> is propagated to connection open and
+/// transaction begin. Commit and rollback run with <see cref="CancellationToken.None"/>
+/// so that cleanup cannot be interrupted by a cancellation arriving after the handler completes.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code>
@@ -80,8 +85,8 @@ public sealed class TransactionPipelineBehavior<TRequest, TResponse> : IPipeline
             var result = await nextStep().ConfigureAwait(false);
 
             await result.Match(
-                Right: _ => CommitAsync(transaction, cancellationToken),
-                Left: _ => RollbackAsync(transaction, cancellationToken)).ConfigureAwait(false);
+                Right: _ => CommitAsync(transaction, CancellationToken.None),
+                Left: _ => RollbackAsync(transaction, CancellationToken.None)).ConfigureAwait(false);
 
             return result;
         }

--- a/src/Encina.Messaging/TransactionPipelineBehavior.cs
+++ b/src/Encina.Messaging/TransactionPipelineBehavior.cs
@@ -115,27 +115,25 @@ public sealed class TransactionPipelineBehavior<TRequest, TResponse> : IPipeline
         }
     }
 
-    private static async Task CommitAsync(IDbTransaction transaction, CancellationToken cancellationToken)
+    private static Task CommitAsync(IDbTransaction transaction, CancellationToken cancellationToken)
     {
         if (transaction is DbTransaction dbTransaction)
         {
-            await dbTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return dbTransaction.CommitAsync(cancellationToken).AsTask();
         }
-        else
-        {
-            transaction.Commit();
-        }
+
+        transaction.Commit();
+        return Task.CompletedTask;
     }
 
-    private static async Task RollbackAsync(IDbTransaction transaction, CancellationToken cancellationToken)
+    private static Task RollbackAsync(IDbTransaction transaction, CancellationToken cancellationToken)
     {
         if (transaction is DbTransaction dbTransaction)
         {
-            await dbTransaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            return dbTransaction.RollbackAsync(cancellationToken).AsTask();
         }
-        else
-        {
-            transaction.Rollback();
-        }
+
+        transaction.Rollback();
+        return Task.CompletedTask;
     }
 }

--- a/src/Encina.Messaging/TransactionPipelineBehavior.cs
+++ b/src/Encina.Messaging/TransactionPipelineBehavior.cs
@@ -119,7 +119,7 @@ public sealed class TransactionPipelineBehavior<TRequest, TResponse> : IPipeline
     {
         if (transaction is DbTransaction dbTransaction)
         {
-            return dbTransaction.CommitAsync(cancellationToken).AsTask();
+            return dbTransaction.CommitAsync(cancellationToken);
         }
 
         transaction.Commit();
@@ -130,7 +130,7 @@ public sealed class TransactionPipelineBehavior<TRequest, TResponse> : IPipeline
     {
         if (transaction is DbTransaction dbTransaction)
         {
-            return dbTransaction.RollbackAsync(cancellationToken).AsTask();
+            return dbTransaction.RollbackAsync(cancellationToken);
         }
 
         transaction.Rollback();

--- a/src/Encina.Messaging/TransactionPipelineBehavior.cs
+++ b/src/Encina.Messaging/TransactionPipelineBehavior.cs
@@ -21,8 +21,10 @@ namespace Encina.Messaging;
 /// </para>
 /// <para>
 /// The caller's <see cref="CancellationToken"/> is propagated to connection open and
-/// transaction begin. Commit and rollback run with <see cref="CancellationToken.None"/>
-/// so that cleanup cannot be interrupted by a cancellation arriving after the handler completes.
+/// transaction begin when token-aware <see cref="DbConnection"/> APIs are available;
+/// otherwise synchronous <see cref="IDbConnection"/> APIs are used. Commit and rollback
+/// run with <see cref="CancellationToken.None"/> so that transaction cleanup is not
+/// canceled by the caller token, including rollback in cancellation paths.
 /// </para>
 /// </remarks>
 /// <example>

--- a/src/Encina.Messaging/TransactionPipelineBehavior.cs
+++ b/src/Encina.Messaging/TransactionPipelineBehavior.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using LanguageExt;
 
 namespace Encina.Messaging;
@@ -56,35 +57,78 @@ public sealed class TransactionPipelineBehavior<TRequest, TResponse> : IPipeline
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(nextStep);
 
-        // Open connection if needed
+        var dbConnection = _connection as DbConnection;
+
         if (_connection.State != ConnectionState.Open)
         {
-            _connection.Open();
+            if (dbConnection is not null)
+            {
+                await dbConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                _connection.Open();
+            }
         }
 
-        // Begin transaction
-        using var transaction = _connection.BeginTransaction();
+        var transaction = dbConnection is not null
+            ? await dbConnection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false)
+            : _connection.BeginTransaction();
 
         try
         {
             var result = await nextStep();
 
-            // Commit on success, rollback on error
-            result.Match(
-                Right: _ => transaction.Commit(),
-                Left: _ => transaction.Rollback());
+            await result.Match(
+                Right: _ => CommitAsync(transaction, cancellationToken),
+                Left: _ => RollbackAsync(transaction, cancellationToken)).ConfigureAwait(false);
 
             return result;
         }
         catch (OperationCanceledException)
         {
-            transaction.Rollback();
+            await RollbackAsync(transaction, CancellationToken.None).ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
         {
-            transaction.Rollback();
+            await RollbackAsync(transaction, CancellationToken.None).ConfigureAwait(false);
             return EncinaErrors.FromException("transaction.failed", ex);
+        }
+        finally
+        {
+            if (transaction is DbTransaction dbTransaction)
+            {
+                await dbTransaction.DisposeAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                transaction.Dispose();
+            }
+        }
+    }
+
+    private static async Task CommitAsync(IDbTransaction transaction, CancellationToken cancellationToken)
+    {
+        if (transaction is DbTransaction dbTransaction)
+        {
+            await dbTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            transaction.Commit();
+        }
+    }
+
+    private static async Task RollbackAsync(IDbTransaction transaction, CancellationToken cancellationToken)
+    {
+        if (transaction is DbTransaction dbTransaction)
+        {
+            await dbTransaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            transaction.Rollback();
         }
     }
 }

--- a/tests/Encina.UnitTests/Messaging/Behaviors/TransactionPipelineBehaviorTests.cs
+++ b/tests/Encina.UnitTests/Messaging/Behaviors/TransactionPipelineBehaviorTests.cs
@@ -350,6 +350,32 @@ public sealed class TransactionPipelineBehaviorTests
         fakeConnection.FakeTransaction.RollbackAsyncToken.ShouldBe(CancellationToken.None);
     }
 
+    [Fact]
+    public async Task Handle_DbConnection_HandlerThrowsOperationCanceled_RollsBackAndRethrows()
+    {
+        // Arrange
+        var fakeConnection = new FakeDbConnection();
+        fakeConnection.SetState(ConnectionState.Open);
+
+        var behavior = new TransactionPipelineBehavior<TestRequest, string>(fakeConnection);
+        var request = new TestRequest(Guid.NewGuid());
+        var context = CreateTestContext();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        RequestHandlerCallback<string> nextStep = () =>
+            throw new OperationCanceledException(cts.Token);
+
+        // Act
+        var act = async () => await behavior.Handle(request, context, nextStep, cts.Token);
+
+        // Assert
+        await act.ShouldThrowAsync<OperationCanceledException>();
+        fakeConnection.FakeTransaction.RollbackAsyncCalls.ShouldBe(1);
+        fakeConnection.FakeTransaction.DisposeAsyncCalls.ShouldBe(1);
+        fakeConnection.FakeTransaction.RollbackAsyncToken.ShouldBe(CancellationToken.None);
+    }
+
     #endregion
 
     #region Helpers

--- a/tests/Encina.UnitTests/Messaging/Behaviors/TransactionPipelineBehaviorTests.cs
+++ b/tests/Encina.UnitTests/Messaging/Behaviors/TransactionPipelineBehaviorTests.cs
@@ -294,7 +294,7 @@ public sealed class TransactionPipelineBehaviorTests
         fakeConnection.FakeTransaction.RollbackAsyncCalls.ShouldBe(0);
         fakeConnection.FakeTransaction.DisposeAsyncCalls.ShouldBe(1);
         fakeConnection.BeginTransactionAsyncToken.ShouldBe(cts.Token);
-        fakeConnection.FakeTransaction.CommitAsyncToken.ShouldBe(cts.Token);
+        fakeConnection.FakeTransaction.CommitAsyncToken.ShouldBe(CancellationToken.None);
     }
 
     [Fact]
@@ -322,7 +322,7 @@ public sealed class TransactionPipelineBehaviorTests
         fakeConnection.FakeTransaction.RollbackCalls.ShouldBe(0);
         fakeConnection.FakeTransaction.CommitAsyncCalls.ShouldBe(0);
         fakeConnection.FakeTransaction.DisposeAsyncCalls.ShouldBe(1);
-        fakeConnection.FakeTransaction.RollbackAsyncToken.ShouldBe(cts.Token);
+        fakeConnection.FakeTransaction.RollbackAsyncToken.ShouldBe(CancellationToken.None);
     }
 
     [Fact]

--- a/tests/Encina.UnitTests/Messaging/Behaviors/TransactionPipelineBehaviorTests.cs
+++ b/tests/Encina.UnitTests/Messaging/Behaviors/TransactionPipelineBehaviorTests.cs
@@ -431,7 +431,7 @@ public sealed class TransactionPipelineBehaviorTests
         public override ValueTask DisposeAsync()
         {
             DisposeAsyncCalls++;
-            return ValueTask.CompletedTask;
+            return base.DisposeAsync();
         }
     }
 

--- a/tests/Encina.UnitTests/Messaging/Behaviors/TransactionPipelineBehaviorTests.cs
+++ b/tests/Encina.UnitTests/Messaging/Behaviors/TransactionPipelineBehaviorTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 using Encina.Messaging;
 using LanguageExt;
 
@@ -240,6 +241,108 @@ public sealed class TransactionPipelineBehaviorTests
 
     #endregion
 
+    #region Handle Tests - Async Path (DbConnection)
+
+    [Fact]
+    public async Task Handle_DbConnectionClosed_OpensConnectionAsync()
+    {
+        // Arrange
+        var fakeConnection = new FakeDbConnection();
+        fakeConnection.SetState(ConnectionState.Closed);
+
+        var behavior = new TransactionPipelineBehavior<TestRequest, string>(fakeConnection);
+        var request = new TestRequest(Guid.NewGuid());
+        var context = CreateTestContext();
+
+        RequestHandlerCallback<string> nextStep = () =>
+            ValueTask.FromResult<Either<EncinaError, string>>("Success");
+
+        // Act
+        await behavior.Handle(request, context, nextStep, CancellationToken.None);
+
+        // Assert
+        fakeConnection.OpenAsyncCalls.ShouldBe(1);
+        fakeConnection.OpenCalls.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Handle_DbConnection_UsesBeginTransactionAsync_AndCommitAsync()
+    {
+        // Arrange
+        var fakeConnection = new FakeDbConnection();
+        fakeConnection.SetState(ConnectionState.Open);
+
+        var behavior = new TransactionPipelineBehavior<TestRequest, string>(fakeConnection);
+        var request = new TestRequest(Guid.NewGuid());
+        var context = CreateTestContext();
+
+        RequestHandlerCallback<string> nextStep = () =>
+            ValueTask.FromResult<Either<EncinaError, string>>("Success");
+
+        // Act
+        var result = await behavior.Handle(request, context, nextStep, CancellationToken.None);
+
+        // Assert
+        result.IsRight.ShouldBeTrue();
+        fakeConnection.BeginTransactionAsyncCalls.ShouldBe(1);
+        fakeConnection.BeginTransactionCalls.ShouldBe(0);
+        fakeConnection.FakeTransaction.CommitAsyncCalls.ShouldBe(1);
+        fakeConnection.FakeTransaction.CommitCalls.ShouldBe(0);
+        fakeConnection.FakeTransaction.RollbackAsyncCalls.ShouldBe(0);
+        fakeConnection.FakeTransaction.DisposeAsyncCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Handle_DbConnection_HandlerReturnsError_UsesRollbackAsync()
+    {
+        // Arrange
+        var fakeConnection = new FakeDbConnection();
+        fakeConnection.SetState(ConnectionState.Open);
+
+        var behavior = new TransactionPipelineBehavior<TestRequest, string>(fakeConnection);
+        var request = new TestRequest(Guid.NewGuid());
+        var context = CreateTestContext();
+        var error = EncinaErrors.Create("test.error", "Test error");
+
+        RequestHandlerCallback<string> nextStep = () =>
+            ValueTask.FromResult<Either<EncinaError, string>>(error);
+
+        // Act
+        var result = await behavior.Handle(request, context, nextStep, CancellationToken.None);
+
+        // Assert
+        result.IsLeft.ShouldBeTrue();
+        fakeConnection.FakeTransaction.RollbackAsyncCalls.ShouldBe(1);
+        fakeConnection.FakeTransaction.RollbackCalls.ShouldBe(0);
+        fakeConnection.FakeTransaction.CommitAsyncCalls.ShouldBe(0);
+        fakeConnection.FakeTransaction.DisposeAsyncCalls.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Handle_DbConnection_HandlerThrows_UsesRollbackAsync()
+    {
+        // Arrange
+        var fakeConnection = new FakeDbConnection();
+        fakeConnection.SetState(ConnectionState.Open);
+
+        var behavior = new TransactionPipelineBehavior<TestRequest, string>(fakeConnection);
+        var request = new TestRequest(Guid.NewGuid());
+        var context = CreateTestContext();
+
+        RequestHandlerCallback<string> nextStep = () =>
+            throw new InvalidOperationException("Handler failed");
+
+        // Act
+        var result = await behavior.Handle(request, context, nextStep, CancellationToken.None);
+
+        // Assert
+        result.IsLeft.ShouldBeTrue();
+        fakeConnection.FakeTransaction.RollbackAsyncCalls.ShouldBe(1);
+        fakeConnection.FakeTransaction.DisposeAsyncCalls.ShouldBe(1);
+    }
+
+    #endregion
+
     #region Helpers
 
     private static IRequestContext CreateTestContext()
@@ -249,6 +352,99 @@ public sealed class TransactionPipelineBehaviorTests
         context.UserId.Returns("test-user");
         context.Timestamp.Returns(DateTimeOffset.UtcNow);
         return context;
+    }
+
+    private sealed class FakeDbTransaction : DbTransaction
+    {
+        public int CommitCalls { get; private set; }
+        public int CommitAsyncCalls { get; private set; }
+        public int RollbackCalls { get; private set; }
+        public int RollbackAsyncCalls { get; private set; }
+        public int DisposeCalls { get; private set; }
+        public int DisposeAsyncCalls { get; private set; }
+
+        public override IsolationLevel IsolationLevel => IsolationLevel.Unspecified;
+        protected override DbConnection? DbConnection => null;
+
+        public override void Commit() => CommitCalls++;
+
+        public override Task CommitAsync(CancellationToken cancellationToken = default)
+        {
+            CommitAsyncCalls++;
+            return Task.CompletedTask;
+        }
+
+        public override void Rollback() => RollbackCalls++;
+
+        public override Task RollbackAsync(CancellationToken cancellationToken = default)
+        {
+            RollbackAsyncCalls++;
+            return Task.CompletedTask;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                DisposeCalls++;
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            DisposeAsyncCalls++;
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private sealed class FakeDbConnection : DbConnection
+    {
+        private ConnectionState _state = ConnectionState.Closed;
+
+        public int OpenCalls { get; private set; }
+        public int OpenAsyncCalls { get; private set; }
+        public int BeginTransactionCalls { get; private set; }
+        public int BeginTransactionAsyncCalls { get; private set; }
+        public FakeDbTransaction FakeTransaction { get; } = new();
+
+        [System.Diagnostics.CodeAnalysis.AllowNull]
+        public override string ConnectionString { get; set; } = string.Empty;
+        public override string Database => string.Empty;
+        public override string DataSource => string.Empty;
+        public override string ServerVersion => string.Empty;
+        public override ConnectionState State => _state;
+
+        public void SetState(ConnectionState state) => _state = state;
+
+        public override void ChangeDatabase(string databaseName) { }
+
+        public override void Close() => _state = ConnectionState.Closed;
+
+        public override void Open()
+        {
+            OpenCalls++;
+            _state = ConnectionState.Open;
+        }
+
+        public override Task OpenAsync(CancellationToken cancellationToken)
+        {
+            OpenAsyncCalls++;
+            _state = ConnectionState.Open;
+            return Task.CompletedTask;
+        }
+
+        protected override DbCommand CreateDbCommand() => throw new NotImplementedException();
+
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        {
+            BeginTransactionCalls++;
+            return FakeTransaction;
+        }
+
+        protected override ValueTask<DbTransaction> BeginDbTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken)
+        {
+            BeginTransactionAsyncCalls++;
+            return ValueTask.FromResult<DbTransaction>(FakeTransaction);
+        }
     }
 
     #endregion

--- a/tests/Encina.UnitTests/Messaging/Behaviors/TransactionPipelineBehaviorTests.cs
+++ b/tests/Encina.UnitTests/Messaging/Behaviors/TransactionPipelineBehaviorTests.cs
@@ -428,10 +428,10 @@ public sealed class TransactionPipelineBehaviorTests
             base.Dispose(disposing);
         }
 
-        public override async ValueTask DisposeAsync()
+        public override ValueTask DisposeAsync()
         {
             DisposeAsyncCalls++;
-            await base.DisposeAsync().ConfigureAwait(false);
+            return ValueTask.CompletedTask;
         }
     }
 

--- a/tests/Encina.UnitTests/Messaging/Behaviors/TransactionPipelineBehaviorTests.cs
+++ b/tests/Encina.UnitTests/Messaging/Behaviors/TransactionPipelineBehaviorTests.cs
@@ -253,16 +253,18 @@ public sealed class TransactionPipelineBehaviorTests
         var behavior = new TransactionPipelineBehavior<TestRequest, string>(fakeConnection);
         var request = new TestRequest(Guid.NewGuid());
         var context = CreateTestContext();
+        using var cts = new CancellationTokenSource();
 
         RequestHandlerCallback<string> nextStep = () =>
             ValueTask.FromResult<Either<EncinaError, string>>("Success");
 
         // Act
-        await behavior.Handle(request, context, nextStep, CancellationToken.None);
+        await behavior.Handle(request, context, nextStep, cts.Token);
 
         // Assert
         fakeConnection.OpenAsyncCalls.ShouldBe(1);
         fakeConnection.OpenCalls.ShouldBe(0);
+        fakeConnection.OpenAsyncToken.ShouldBe(cts.Token);
     }
 
     [Fact]
@@ -275,12 +277,13 @@ public sealed class TransactionPipelineBehaviorTests
         var behavior = new TransactionPipelineBehavior<TestRequest, string>(fakeConnection);
         var request = new TestRequest(Guid.NewGuid());
         var context = CreateTestContext();
+        using var cts = new CancellationTokenSource();
 
         RequestHandlerCallback<string> nextStep = () =>
             ValueTask.FromResult<Either<EncinaError, string>>("Success");
 
         // Act
-        var result = await behavior.Handle(request, context, nextStep, CancellationToken.None);
+        var result = await behavior.Handle(request, context, nextStep, cts.Token);
 
         // Assert
         result.IsRight.ShouldBeTrue();
@@ -290,6 +293,8 @@ public sealed class TransactionPipelineBehaviorTests
         fakeConnection.FakeTransaction.CommitCalls.ShouldBe(0);
         fakeConnection.FakeTransaction.RollbackAsyncCalls.ShouldBe(0);
         fakeConnection.FakeTransaction.DisposeAsyncCalls.ShouldBe(1);
+        fakeConnection.BeginTransactionAsyncToken.ShouldBe(cts.Token);
+        fakeConnection.FakeTransaction.CommitAsyncToken.ShouldBe(cts.Token);
     }
 
     [Fact]
@@ -303,12 +308,13 @@ public sealed class TransactionPipelineBehaviorTests
         var request = new TestRequest(Guid.NewGuid());
         var context = CreateTestContext();
         var error = EncinaErrors.Create("test.error", "Test error");
+        using var cts = new CancellationTokenSource();
 
         RequestHandlerCallback<string> nextStep = () =>
             ValueTask.FromResult<Either<EncinaError, string>>(error);
 
         // Act
-        var result = await behavior.Handle(request, context, nextStep, CancellationToken.None);
+        var result = await behavior.Handle(request, context, nextStep, cts.Token);
 
         // Assert
         result.IsLeft.ShouldBeTrue();
@@ -316,10 +322,11 @@ public sealed class TransactionPipelineBehaviorTests
         fakeConnection.FakeTransaction.RollbackCalls.ShouldBe(0);
         fakeConnection.FakeTransaction.CommitAsyncCalls.ShouldBe(0);
         fakeConnection.FakeTransaction.DisposeAsyncCalls.ShouldBe(1);
+        fakeConnection.FakeTransaction.RollbackAsyncToken.ShouldBe(cts.Token);
     }
 
     [Fact]
-    public async Task Handle_DbConnection_HandlerThrows_UsesRollbackAsync()
+    public async Task Handle_DbConnection_HandlerThrows_UsesRollbackAsyncWithoutPropagatingCallerToken()
     {
         // Arrange
         var fakeConnection = new FakeDbConnection();
@@ -328,17 +335,19 @@ public sealed class TransactionPipelineBehaviorTests
         var behavior = new TransactionPipelineBehavior<TestRequest, string>(fakeConnection);
         var request = new TestRequest(Guid.NewGuid());
         var context = CreateTestContext();
+        using var cts = new CancellationTokenSource();
 
         RequestHandlerCallback<string> nextStep = () =>
             throw new InvalidOperationException("Handler failed");
 
         // Act
-        var result = await behavior.Handle(request, context, nextStep, CancellationToken.None);
+        var result = await behavior.Handle(request, context, nextStep, cts.Token);
 
         // Assert
         result.IsLeft.ShouldBeTrue();
         fakeConnection.FakeTransaction.RollbackAsyncCalls.ShouldBe(1);
         fakeConnection.FakeTransaction.DisposeAsyncCalls.ShouldBe(1);
+        fakeConnection.FakeTransaction.RollbackAsyncToken.ShouldBe(CancellationToken.None);
     }
 
     #endregion
@@ -362,6 +371,8 @@ public sealed class TransactionPipelineBehaviorTests
         public int RollbackAsyncCalls { get; private set; }
         public int DisposeCalls { get; private set; }
         public int DisposeAsyncCalls { get; private set; }
+        public CancellationToken CommitAsyncToken { get; private set; }
+        public CancellationToken RollbackAsyncToken { get; private set; }
 
         public override IsolationLevel IsolationLevel => IsolationLevel.Unspecified;
         protected override DbConnection? DbConnection => null;
@@ -371,6 +382,7 @@ public sealed class TransactionPipelineBehaviorTests
         public override Task CommitAsync(CancellationToken cancellationToken = default)
         {
             CommitAsyncCalls++;
+            CommitAsyncToken = cancellationToken;
             return Task.CompletedTask;
         }
 
@@ -379,6 +391,7 @@ public sealed class TransactionPipelineBehaviorTests
         public override Task RollbackAsync(CancellationToken cancellationToken = default)
         {
             RollbackAsyncCalls++;
+            RollbackAsyncToken = cancellationToken;
             return Task.CompletedTask;
         }
 
@@ -404,6 +417,8 @@ public sealed class TransactionPipelineBehaviorTests
         public int OpenAsyncCalls { get; private set; }
         public int BeginTransactionCalls { get; private set; }
         public int BeginTransactionAsyncCalls { get; private set; }
+        public CancellationToken OpenAsyncToken { get; private set; }
+        public CancellationToken BeginTransactionAsyncToken { get; private set; }
         public FakeDbTransaction FakeTransaction { get; } = new();
 
         [System.Diagnostics.CodeAnalysis.AllowNull]
@@ -428,6 +443,7 @@ public sealed class TransactionPipelineBehaviorTests
         public override Task OpenAsync(CancellationToken cancellationToken)
         {
             OpenAsyncCalls++;
+            OpenAsyncToken = cancellationToken;
             _state = ConnectionState.Open;
             return Task.CompletedTask;
         }
@@ -443,6 +459,7 @@ public sealed class TransactionPipelineBehaviorTests
         protected override ValueTask<DbTransaction> BeginDbTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken)
         {
             BeginTransactionAsyncCalls++;
+            BeginTransactionAsyncToken = cancellationToken;
             return ValueTask.FromResult<DbTransaction>(FakeTransaction);
         }
     }


### PR DESCRIPTION
## Summary
- Replaces synchronous `IDbConnection.Open()` and `BeginTransaction()` calls in `TransactionPipelineBehavior<TRequest, TResponse>` with async variants when the underlying connection derives from `DbConnection`.
- Uses `OpenAsync`, `BeginTransactionAsync`, `CommitAsync`, `RollbackAsync` and `DisposeAsync` (all with `CancellationToken` plumbed through) to avoid blocking the ThreadPool on I/O.
- Keeps a synchronous fallback for exotic `IDbConnection` implementations that do not derive from `DbConnection`.

Fixes #794

## Test plan
- [x] New unit tests exercise the async path via `FakeDbConnection`/`FakeDbTransaction` test doubles (commit, rollback, exception, closed-connection scenarios).
- [x] Existing `IDbConnection` substitute tests still pass (verify the sync fallback).
- [x] `dotnet test tests/Encina.UnitTests` filtered: 18/18 ✅
- [x] `dotnet test tests/Encina.ContractTests` filtered: 5/5 ✅
- [x] `dotnet test tests/Encina.GuardTests` filtered: 20/20 ✅
- [x] Build with `-c Release`: 0 warnings, 0 errors
- [x] Public API surface unchanged (no updates to `PublicAPI.*.txt`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Versión

* **Refactor**
  * Mejorado el manejo de transacciones para priorizar rutas asincrónicas cuando están disponibles: apertura y comienzo de transacción con el token del llamador; confirmación/reversión y limpieza usando variantes asincrónicas o su equivalente síncrono según soporte.

* **Tests**
  * Ampliadas pruebas para cubrir flujos asincrónicos con conexiones capaces de async, verificando uso de métodos async, manejo de cancelación, confirmación/reversión y disposición correcta en distintos escenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->