### PR TITLE
fix(security): bump vulnerable packages (DataProtection 10.0.7, OpenTelemetry 1.15.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 ## [Unreleased] - v0.13.0 - Security & Compliance
 
+### Security
+
+#### Dependency advisories — OpenTelemetry 1.15.3 / Microsoft.AspNetCore.DataProtection 10.0.7 (#1041)
+
+Bumped three transitively-vulnerable packages plus aligned the .NET 10 monthly patch family to 10.0.7 and the OpenTelemetry 1.x family to 1.15.3:
+
+- **[CVE-2026-40372](https://github.com/advisories/GHSA-9mv3-2cwr-p262)** (CVSS 9.1, Critical) — `Microsoft.AspNetCore.DataProtection` 10.0.0–10.0.6 has an HMAC validation bypass that allows forging authentication cookies and decrypting protected payloads. Bumped to **10.0.7**.
+- **[GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j)** (Moderate) — `OpenTelemetry.Api` and `OpenTelemetry.Extensions.Propagators` < 1.15.3 — excessive memory allocation when parsing OpenTelemetry propagation headers. Bumped both to **1.15.3** (Propagators added to central versions defensively).
+- **[GHSA-mr8r-92fq-pj8p](https://github.com/advisories/GHSA-mr8r-92fq-pj8p)** + **[GHSA-q834-8qmm-v933](https://github.com/advisories/GHSA-q834-8qmm-v933)** (Moderate) — `OpenTelemetry.Exporter.OpenTelemetryProtocol` 1.13.1–1.15.2: unbounded `grpc-status-details-bin` parsing in OTLP/gRPC retry handling and unbounded HTTP response body reads. Bumped to **1.15.3**.
+
+**Mitigation guidance for `Microsoft.AspNetCore.DataProtection` consumers (CVE-2026-40372)**
+
+Updating to 10.0.7 fixes the validation bug going forward, but **any cookie / token / payload signed by a key that was active during the vulnerable window remains forgeable until that key is revoked**. After updating, consumers exposed to untrusted traffic should rotate the data-protection key ring:
+
+```csharp
+var keyManager = serviceProvider.GetRequiredService<IKeyManager>();
+keyManager.RevokeAllKeys(
+    revocationDate: DateTimeOffset.UtcNow,
+    reason: "CVE-2026-40372: DataProtection 10.0.6 validation bypass");
+```
+
+`RevokeAllKeys` marks every existing key as revoked; a fresh key is auto-generated on the next `Protect` call. This invalidates all in-flight authentication cookies, antiforgery tokens, and protected payloads — users sign back in, antiforgery tokens reissue.
+
+**Application-level artifacts that survive key-ring rotation must be rotated separately**: API keys, refresh tokens, password-reset links, and any plaintext secrets that travelled inside protected payloads during the vulnerable window are still attacker-controlled even after the key ring rotates. Inventory and rotate them, then audit logs for anomalous activity against protected endpoints during the window.
+
+This mitigation only matters for projects that actually consume `Microsoft.AspNetCore.DataProtection` at runtime. In Encina, the package is referenced by `Encina.Messaging.Encryption.DataProtection`; consumers of that package should follow the rotation guidance above. `Encina.ContractTests` references it for compile-time contract verification only and does not produce runtime tokens.
+
 ### Added
 
 #### Encina.Messaging — Scheduled Message Processor + Retry Policy & Dispatcher Abstractions (#765)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,6 +67,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.13.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Propagators" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
     <PackageVersion Include="Polly" Version="8.6.6" />
     <PackageVersion Include="Respawn" Version="7.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,34 +9,34 @@
     <PackageVersion Include="FsCheck" Version="3.3.2" />
     <PackageVersion Include="FsCheck.Xunit.v3" Version="3.3.2" />
     <PackageVersion Include="LanguageExt.Core" Version="4.4.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="10.23.26100" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.7" />
     <PackageVersion Include="StackExchange.Redis" Version="2.12.14" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <!-- Static Code Analyzers -->
@@ -56,17 +56,17 @@
     <PackageVersion Include="Quartz" Version="3.18.0" />
     <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.18.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
     <PackageVersion Include="MySqlConnector" Version="2.5.0" />
     <PackageVersion Include="Npgsql" Version="10.0.2" />
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.26.100" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.13.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
     <PackageVersion Include="Polly" Version="8.6.6" />
     <PackageVersion Include="Respawn" Version="7.0.0" />
@@ -117,13 +117,13 @@
     <!-- In-Memory Channel -->
     <PackageVersion Include="System.Threading.Channels" Version="10.0.0" />
     <!-- System.IO.Hashing -->
-    <PackageVersion Include="System.IO.Hashing" Version="10.0.6" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.7" />
     <!-- System.Data -->
     <PackageVersion Include="System.Data.Common" Version="4.3.0" />
     <!-- EventStoreDB -->
     <PackageVersion Include="EventStore.Client.Grpc.Streams" Version="23.3.9" />
     <!-- SignalR -->
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
     <!-- Azure Functions -->
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
@@ -173,8 +173,8 @@
     <PackageVersion Include="AWSSDK.SecretsManager" Version="4.0.4.9" />
     <PackageVersion Include="AWSSDK.KeyManagementService" Version="4.0.9.3" />
     <!-- Data Protection -->
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.6" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <PackageVersion Include="VaultSharp" Version="1.17.5.1" />
     <PackageVersion Include="Google.Cloud.SecretManager.V1" Version="2.7.0" />
     <!-- YAML Parsing -->

--- a/src/Encina.OpenTelemetry/Encina.OpenTelemetry.csproj
+++ b/src/Encina.OpenTelemetry/Encina.OpenTelemetry.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Api" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" PrivateAssets="all" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />

--- a/src/Encina.OpenTelemetry/Encina.OpenTelemetry.csproj
+++ b/src/Encina.OpenTelemetry/Encina.OpenTelemetry.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Api" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />

--- a/src/Encina.Testing.WireMock/Encina.Testing.WireMock.csproj
+++ b/src/Encina.Testing.WireMock/Encina.Testing.WireMock.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" Link="LICENSE" />
   </ItemGroup>

--- a/src/Encina.Testing.WireMock/Encina.Testing.WireMock.csproj
+++ b/src/Encina.Testing.WireMock/Encina.Testing.WireMock.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" PrivateAssets="all" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" Link="LICENSE" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Restore was failing across **CI Full**, **CodeQL**, **Benchmarks**, **Load Tests** and **Mutation Tests** since 2026-04-24 (last green main: [7bf3f259](https://github.com/dlrivada/Encina/commit/7bf3f259)). Three packages were flagged with new GHSA advisories and `NuGetAudit` (NU1902/NU1904) escalates to error via `TreatWarningsAsErrors`.

| Package | From | To | Advisory | Severity |
|---|---|---|---|---|
| `Microsoft.AspNetCore.DataProtection` | 10.0.6 | **10.0.7** | [CVE-2026-40372](https://github.com/advisories/GHSA-9mv3-2cwr-p262) | **Critical** |
| `OpenTelemetry.Api` | 1.15.2 | **1.15.3** | [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) | Moderate |
| `OpenTelemetry.Exporter.OpenTelemetryProtocol` | 1.14.0 | **1.15.3** | [GHSA-mr8r-92fq-pj8p](https://github.com/advisories/GHSA-mr8r-92fq-pj8p), [GHSA-q834-8qmm-v933](https://github.com/advisories/GHSA-q834-8qmm-v933) | Moderate |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## What changed

1. **3 vulnerable packages bumped** (table above).
2. **Aligned the .NET 10 monthly patch family to 10.0.7** to avoid NU1605 transitive downgrades pulled in by `DataProtection 10.0.7` (which requires DI/Logging/Options/CryptoXml at >=10.0.7). Affected: all `Microsoft.Extensions.*`, `Microsoft.EntityFrameworkCore.*`, `Microsoft.AspNetCore.*`, `Microsoft.Data.Sqlite`, `System.IO.Hashing`, `System.Security.Cryptography.Xml`.
3. **Aligned OpenTelemetry 1.x family to 1.15.3** for consistency: `OpenTelemetry`, `OpenTelemetry.Exporter.Console`, `OpenTelemetry.Extensions.Hosting`. Left `OpenTelemetry.Instrumentation.Runtime 1.15.0` and `OpenTelemetry.Exporter.Prometheus.AspNetCore 1.13.0-beta.1` alone (independent versioning tracks).
4. **Added direct `PackageReference` for `OpenTelemetry.Exporter.OpenTelemetryProtocol`** in `Encina.OpenTelemetry.csproj` and `Encina.Testing.WireMock.csproj`. Without a direct reference, NuGet was resolving the package transitively at 1.14.0 in test projects (CPM does not pin transitive deps unless `CentralPackageTransitivePinningEnabled` is on, which surfaces unrelated pre-existing conflicts in Marten/CodeAnalysis/Grpc.Tools and is out of scope for this PR).

## Checklist

- [x] Code follows the project's coding standards
- [x] `dotnet build` passes with `TreatWarningsAsErrors` (0 warnings, 0 errors locally)
- [x] `dotnet restore` resolves cleanly with `--force-evaluate`
- [ ] `dotnet test Encina.slnx --configuration Release` (deferred to CI — the change is dependency versions, not code)
- [x] No public API changes (PublicAPI.\*.txt untouched)
- [x] CHANGELOG.md not updated — security patch bump, will be captured in next release notes

## Cross-Cutting Integration

N/A — dependency security patch, no behavior change.

## Related Issues

Closes none (no pre-existing issue tracked the failures yet).

## Notes / Follow-ups

- The Dependabot `nuget` job has been timing out at the 1h GitHub limit (run [24998763697](https://github.com/dlrivada/Encina/actions/runs/24998763697)) — likely the reason this slipped past automated security updates. Will track separately as `[INFRA]`.
- The `CentralPackageTransitivePinningEnabled` route was tried and reverted: it surfaces pre-existing conflicts in `Microsoft.CodeAnalysis.Common` (4.14.0 vs 5.0.0 via Marten/JasperFx) and `Grpc.Tools` (Aspire 13.2.2 wants 2.78.0, central is 2.71.0). Worth a separate cleanup PR if we want to enable transitive pinning long-term.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lanzamiento

* **Chores**
  * Actualización de dependencias de framework y bibliotecas a versiones más recientes para mejorar compatibilidad y seguridad.

* **New Features**
  * Añadido soporte para exportación de telemetría mediante protocolo OTLP en componentes relevantes.

* **Documentation**
  * Añadido registro de cambios con orientación de mitigación y pasos para rotación/revocación de claves y artefactos relacionados.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->