### PR TITLE
ci(dependabot): split nuget into 3 parallel jobs to fix 1h timeout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -195,6 +195,8 @@ updates:
     cooldown:
       default-days: 3
       semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
     groups:
       nuget-tools:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,210 @@
 # Dependabot configuration
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+#
+# NuGet is split into three parallel jobs (src/, tests/, tools/) because the
+# repository has 156 .csproj files and a single root-scoped run iterates each
+# project sequentially, hitting the 45-min internal updater timeout (and ~1h
+# GitHub job timeout) before any PR is produced. See issue #1042.
+#
+# Aggressive grouping by package family + cooldown reduces PR volume and
+# spreads updates across runs. Security updates bypass cooldown automatically,
+# so GHSA advisories still flow through without delay.
 
 version: 2
+
 updates:
-  # NuGet packages
+  # NuGet — src/ (110 csproj files; the heavy job)
   - package-ecosystem: "nuget"
-    directory: "/"
+    directory: "/src"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 15
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
     groups:
-      # Group minor/patch updates to reduce PR noise
-      nuget-minor:
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+          - "Microsoft.Bcl.*"
+          - "System.*"
+        update-types: ["minor", "patch"]
+      microsoft-aspnetcore:
+        patterns:
+          - "Microsoft.AspNetCore.*"
+        update-types: ["minor", "patch"]
+      microsoft-efcore:
+        patterns:
+          - "Microsoft.EntityFrameworkCore*"
+          - "Microsoft.Data.*"
+          - "Pomelo.*"
+          - "Npgsql*"
+          - "MySqlConnector"
+          - "Oracle.*"
+        update-types: ["minor", "patch"]
+      microsoft-codeanalysis:
+        patterns:
+          - "Microsoft.CodeAnalysis.*"
+          - "Roslynator.*"
+          - "SonarAnalyzer.*"
+          - "Meziantou.*"
+          - "JetBrains.Annotations"
+        update-types: ["minor", "patch"]
+      aws-sdk:
+        patterns:
+          - "AWSSDK.*"
+          - "Amazon.*"
+        update-types: ["minor", "patch"]
+      azure:
+        patterns:
+          - "Azure.*"
+          - "Microsoft.Azure.*"
+        update-types: ["minor", "patch"]
+      opentelemetry:
+        patterns:
+          - "OpenTelemetry*"
+        update-types: ["minor", "patch"]
+      aspire:
+        patterns:
+          - "Aspire.*"
+        update-types: ["minor", "patch"]
+      grpc:
+        patterns:
+          - "Grpc.*"
+        update-types: ["minor", "patch"]
+      hangfire:
+        patterns:
+          - "Hangfire.*"
+        update-types: ["minor", "patch"]
+      dapr:
+        patterns:
+          - "Dapr.*"
+        update-types: ["minor", "patch"]
+      hotchocolate:
+        patterns:
+          - "HotChocolate*"
+        update-types: ["minor", "patch"]
+      sentry:
+        patterns:
+          - "Sentry*"
+        update-types: ["minor", "patch"]
+      # Catch-all for everything else (low-volume packages)
+      nuget-other:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
+        exclude-patterns:
+          - "Microsoft.Extensions.*"
+          - "Microsoft.Bcl.*"
+          - "System.*"
+          - "Microsoft.AspNetCore.*"
+          - "Microsoft.EntityFrameworkCore*"
+          - "Microsoft.Data.*"
+          - "Pomelo.*"
+          - "Npgsql*"
+          - "MySqlConnector"
+          - "Oracle.*"
+          - "Microsoft.CodeAnalysis.*"
+          - "Roslynator.*"
+          - "SonarAnalyzer.*"
+          - "Meziantou.*"
+          - "JetBrains.Annotations"
+          - "AWSSDK.*"
+          - "Amazon.*"
+          - "Azure.*"
+          - "Microsoft.Azure.*"
+          - "OpenTelemetry*"
+          - "Aspire.*"
+          - "Grpc.*"
+          - "Hangfire.*"
+          - "Dapr.*"
+          - "HotChocolate*"
+          - "Sentry*"
+        update-types: ["minor", "patch"]
     labels:
       - "dependencies"
       - "nuget"
     commit-message:
       prefix: "deps"
+
+  # NuGet — tests/ (45 csproj files; mostly test-only packages)
+  - package-ecosystem: "nuget"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 1
+    groups:
+      xunit:
+        patterns:
+          - "xunit.*"
+          - "coverlet.*"
+        update-types: ["minor", "patch"]
+      testcontainers:
+        patterns:
+          - "Testcontainers*"
+        update-types: ["minor", "patch"]
+      microsoft-test-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+          - "Microsoft.NET.Test.*"
+          - "Microsoft.AspNetCore.*"
+        update-types: ["minor", "patch"]
+      verify:
+        patterns:
+          - "Verify*"
+        update-types: ["minor", "patch"]
+      archunit:
+        patterns:
+          - "TngTech.*"
+        update-types: ["minor", "patch"]
+      # Catch-all for everything else (NSubstitute, Bogus, FsCheck, Shouldly, etc.)
+      nuget-test-other:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "xunit.*"
+          - "coverlet.*"
+          - "Testcontainers*"
+          - "Microsoft.Extensions.*"
+          - "Microsoft.NET.Test.*"
+          - "Microsoft.AspNetCore.*"
+          - "Verify*"
+          - "TngTech.*"
+        update-types: ["minor", "patch"]
+    labels:
+      - "dependencies"
+      - "nuget"
+    commit-message:
+      prefix: "deps(tests)"
+
+  # NuGet — tools/ (1 csproj; trivial scope)
+  - package-ecosystem: "nuget"
+    directory: "/tools"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+    groups:
+      nuget-tools:
+        patterns:
+          - "*"
+        update-types: ["minor", "patch"]
+    labels:
+      - "dependencies"
+      - "nuget"
+    commit-message:
+      prefix: "deps(tools)"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

- Split the single nuget Dependabot job into three parallel ecosystem entries scoped to `/src` (110 csproj), `/tests` (45 csproj), and `/tools` (1 csproj). Each becomes its own GitHub Actions workflow run, getting its own time budget.
- Add aggressive grouping by package family (Microsoft.Extensions, EFCore, AspNetCore, AWS, Azure, OpenTelemetry, Aspire, gRPC, Hangfire, Dapr, HotChocolate, Sentry, xunit, Testcontainers, Verify, ArchUnitNET) with catch-all groups for the long tail.
- Add cooldown (3 default / 7 major / 3 minor / 1 patch days) to spread updates and let releases settle. Security updates bypass cooldown automatically.

## Why

The previous single root-scoped nuget job iterated all 156 csproj files sequentially and consistently hit the ~45-min internal updater timeout (and ~1h GitHub job timeout) before producing any PR. Last two scheduled runs ([24998763697](https://github.com/dlrivada/Encina/actions/runs/24998763697), [24668548522](https://github.com/dlrivada/Encina/actions/runs/24668548522)) were both cancelled at ~55 min.

Knock-on effect: GHSA advisories did not reach `main` automatically. The DataProtection critical CVE and two OpenTelemetry moderates from [#1041](https://github.com/dlrivada/Encina/pull/1041) had to be patched by hand instead of arriving as a Dependabot security PR within 24h of the advisory landing.

## How it should help

| Concern | Before | After |
|---|---|---|
| Wall clock | 1 job × 156 csproj sequential → ~55 min, cancelled | 3 parallel jobs (110/45/1 csproj) → heavy `/src` job ~25-35 min |
| PR volume | Up to 159 individual PRs/week | ~28 grouped PRs/week max (most empty) |
| Security PRs | Blocked by analysis timeout | Flow through (security updates bypass cooldown) |
| Update coverage | All 159 packages | All 159 packages (catch-all groups ensure no regression) |

## Pattern coverage verification

Cross-checked all 159 packages in `Directory.Packages.props` against the group patterns. In the `/src` scope:

- 13 explicit family groups capture 94 packages
- 1 catch-all group captures the remaining 65 (low-volume packages like Marten, MassTransit, NServiceBus, Polly, Quartz, Refit, etc.)
- All meta-packages (HotChocolate, OpenTelemetry, Sentry, Microsoft.EntityFrameworkCore, Testcontainers) correctly matched via `*` glob style (e.g., `OpenTelemetry*` matches both `OpenTelemetry` and `OpenTelemetry.Api`)

## Risks

- **Duplicate-PR risk for cross-scope packages**: A package referenced from both `/src` and `/tests` (e.g., shared BCL types) could trigger PRs from both scopes. In practice most packages are scope-specific and grouping makes the duplicates idempotent (same group → same target version).
- **First run after merge**: There may be an initial burst of catch-up PRs. `open-pull-requests-limit: 15` in `/src` absorbs that.

## Acceptance criteria from #1042

- [ ] Scheduled `nuget` Dependabot run completes within the GitHub timeout — verify next Monday
- [ ] At least one auto-generated update PR lands successfully on `main`
- [x] No regression in update coverage — verified by pattern cross-check (all 159 central packages reachable)
- [ ] No timeouts for at least 2 consecutive scheduled runs

## Test plan

- [ ] Wait for next scheduled run (Monday 2026-05-04) — confirm all three nuget workflows complete
- [ ] Optionally trigger a manual run via the Dependabot dashboard to validate sooner
- [ ] Verify at least one grouped PR opens (likely from `/src` microsoft-extensions or aws-sdk)
- [ ] Verify no duplicate PRs across `/src` and `/tests` scopes for shared packages
- [ ] Confirm github-actions ecosystem entry still works (untouched)

Closes #1042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tareas**
  * Optimizado el sistema de gestión de actualizaciones de dependencias del repositorio para mejorar la distribución y frecuencia de las actualizaciones de paquetes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->